### PR TITLE
Make the task's name editable via contenteditable directive.

### DIFF
--- a/src/client/app/flogo.form-builder/components/form-builder.component.ts
+++ b/src/client/app/flogo.form-builder/components/form-builder.component.ts
@@ -9,13 +9,14 @@ import {FlogoFormBuilderFieldsTextBox as FieldTextBox} from '../../flogo.form-bu
 import {FlogoFormBuilderFieldsParams as FieldParams} from '../../flogo.form-builder.fields/components/fields.params/fields.params.component';
 import {FlogoFormBuilderFieldsTextArea as FieldTextArea} from '../../flogo.form-builder.fields/components/fields.textarea/fields.textarea.component';
 import {FlogoFormBuilderFieldsNumber as FieldNumber} from '../../flogo.form-builder.fields/components/fields.number/fields.number.component';
+import {Contenteditable} from '../../../common/directives/contenteditable.directive';
 
 @Component({
   selector: 'flogo-form-builder',
   moduleId: module.id,
   styleUrls: ['form-builder.css'],
   templateUrl: 'form-builder.tpl.html',
-  directives: [ROUTER_DIRECTIVES, FieldRadio, FieldTextBox, FieldTextArea, FieldNumber, FieldParams ],
+  directives: [ROUTER_DIRECTIVES, FieldRadio, FieldTextBox, FieldTextArea, FieldNumber, FieldParams, Contenteditable],
   inputs: ['_task:task','_step:step', '_context:context']
 })
 export class FlogoFormBuilderComponent{
@@ -359,4 +360,7 @@ export class FlogoFormBuilderComponent{
 
   }
 
+  changeTaskDetail(event: any) {
+    console.log(event);
+  }
 }

--- a/src/client/app/flogo.form-builder/components/form-builder.tpl.html
+++ b/src/client/app/flogo.form-builder/components/form-builder.tpl.html
@@ -14,7 +14,9 @@
       </div>
 
       <div class="flogo-common-edit-panel__head-wrapper">
-        <h3  *ngIf="_task && (_context.isTask || _context.isTrigger)" class="flogo-common-edit-panel__head-title">{{ _task.name || _task.id }}</h3>
+        <div  *ngIf="_task && (_context.isTask || _context.isTrigger)">
+          <h3 [(myContenteditable)]="_task.name" class="flogo-common-edit-panel__head-title" (myContenteditableChange)="changeTaskDetail($event)"></h3>
+        </div>
         <h3  *ngIf="_context.isBranch" class="flogo-common-edit-panel__head-title">Configure Branch</h3>
         <div class="flogo-common-edit-panel__head-subtitle"></div>
       </div>

--- a/src/client/assets/main.css
+++ b/src/client/assets/main.css
@@ -242,9 +242,6 @@ label {
   min-height: 89px;
   max-height: 89px;
   padding: 19px 16px 24px;
-  display: flex;
-  flex-direction:row;
-  align-items: baseline;
 
 }
 
@@ -256,6 +253,7 @@ label {
   font-weight: bold;
   margin: 0;
   padding: 0;
+  line-height: 1.5;
   letter-spacing: 2px;
 }
 


### PR DESCRIPTION
Currently I just implement the contenteditable directive to task's name. With this directive, the task's name is able to be edited, like flow's name and flow's description. 
If I added the placeholder attribute, it means that when the element is empty, it would fill the element with placeholder like the flow's description.
Currently it cannot support uploading the task's name in database.  After the task's name being modified, I just console log the new content. If you need further development, please modify the function changeTaskDetail in form-builder.component.ts.
