### PR TITLE
Fix #205 Error having empty string in pathParams or queryParams in REST Activity

### DIFF
--- a/src/client/app/flogo.form-builder.fields/components/fields.base/fields.base.component.ts
+++ b/src/client/app/flogo.form-builder.fields/components/fields.base/fields.base.component.ts
@@ -41,7 +41,6 @@ export class FlogoFormBuilderFieldsBase{
     var value = event.target.value || '';
 
     if(this._info.required) {
-      debugger;
       if(!value.trim()) {
         //this._errorMessage = this._info.title + ' is required';
         this._errorMessage = this.translate.get('FIELDS-BASE:TITLE-REQUIRED', {value: this._info.title})['value'];

--- a/src/client/app/flogo.form-builder/components/form-builder.component.ts
+++ b/src/client/app/flogo.form-builder/components/form-builder.component.ts
@@ -188,7 +188,7 @@ export class FlogoFormBuilderComponent{
     });
 
     if(item) {
-      item.value = changedObject.value
+      item.value = _.isEmpty(changedObject.value) ? null :changedObject.value;
     }
 
   }


### PR DESCRIPTION
Using the latest 0.2.2 version
If you pass over the pathsParam or queryParams fields (using tab to change field). If, by mistake, you enter character(s), which you immediately delete, then the activity fails at runtime with the following error:
[31m13:20:36.455 Eval ▶ ERROR �[0m Error evaluating activity 'GetTemperature'[tibco-rest] - interface conversion: interface {} is string, not map[string]string
And then your flow is corrupted, no way in the UI to reverse back.
It seems that an empty string is stored in the config value instead of null
