### PR TITLE
Issue #236 - Title now is editable even when is too long

### DIFF
--- a/src/client/common/directives/contenteditable.directive.ts
+++ b/src/client/common/directives/contenteditable.directive.ts
@@ -58,14 +58,22 @@ export class Contenteditable implements OnChanges {
     }
     onMouseLeave() {
         if(document.activeElement != this._el) {
-            this.$el.css({'background': '', 'border': '1px solid transparent'});
+            this.$el.css({
+              'background': '',
+              'border': '1px solid transparent',
+            });
             if(this.colorFlag)  this.$el.css('color', 'rgb(255, 255, 255)');
         } else {
             // omit
         }
     }
     onFocus() {
-        this.$el.css({'background': '#fff', 'border': '1px solid #0082d5'});
+        this.$el.css({
+          'background': '#fff',
+          'border': '1px solid #0082d5',
+          'overflow': 'auto',
+          'text-overflow': 'clip'
+        });
         if(this.colorFlag)  this.$el.css('color', 'rgb(102, 102, 102)');
         if(this.$el.find('span')) {
             this.$el.find('span').eq(0).remove();
@@ -73,7 +81,13 @@ export class Contenteditable implements OnChanges {
     }
     onBlur() {
         if(this.placeholder || this.$el.text() !== '') {
-            this.$el.css({'background': '', 'border': '1px solid transparent'});
+            this.$el.css({
+              'background': '',
+              'border': '1px solid transparent',
+              'overflow': 'hidden',
+              'text-overflow': 'ellipsis',
+            }).scrollLeft(0);
+
             if(this.colorFlag)  this.$el.css('color', 'rgb(255, 255, 255)');
             if(this.$el.text() === '' && this.myContenteditable === undefined) {
                 // omit


### PR DESCRIPTION
Content-editable directive was modified to allow edit the title when is too large. 

Now the title changes it properties allowing to scroll through the content and edit where necessary:  

![screen shot 2016-11-29 at 4 58 51 pm](https://cloud.githubusercontent.com/assets/21316140/20732621/435083b8-b655-11e6-9b21-689d77e7747b.png)

![screen shot 2016-11-29 at 4 59 04 pm](https://cloud.githubusercontent.com/assets/21316140/20732622/4354ec78-b655-11e6-9b5c-e2e4f5525e36.png)

And comes back once the edition is over. 