### PR TITLE
Integrated the Flogo-contrib changes to trigger JSON into flogo-web server

### DIFF
--- a/src/server/modules/triggers/constants.js
+++ b/src/server/modules/triggers/constants.js
@@ -20,6 +20,7 @@ export const PUBLISH_FIELDS_LONG = [
   'ref',
   'settings',
   'outputs',
+  'handler',
   'endpoint'
 ];
 

--- a/src/server/modules/triggers/index.js
+++ b/src/server/modules/triggers/index.js
@@ -43,9 +43,14 @@ export class TriggerManager {
 }
 
 function cleanForOutput(trigger, fields) {
+  // To-Do: remove cleanTrigger.endpoint
   let cleanTrigger = Object.assign(
-    { id: trigger.id || trigger._id },
-    {ref: trigger.ref, homepage: get(trigger,'schema.homepage','')},
+    {
+      id: trigger.id || trigger._id,
+      ref: trigger.ref,
+      homepage: get(trigger, 'schema.homepage', ''),
+      endpoint: get(trigger, 'schema.handler', {'settings': []})
+    },
     trigger.schema
   );
 


### PR DESCRIPTION
Integrated the Trigger JSON changes to flogo-web server side and avoid breaking the flogo-web application at multiple places due to missing endpoint key in trigger details api response.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently the changes to Flogo-Contrib's trigger.json was not integrated with flogo-web server. Due to which the flow details page, export and import application feature is breaking. 


**What is the new behavior?**
We are maintaining the endpoint key in the get Trigger details api call and setting it with trigger.schema.handler value. This endpoint key is needed for having a break free code in flogo-web client side.