### PR TITLE
Deleting the trigger when all flows associated with it are deleted - #387

### DIFF
--- a/src/client/app/flogo.apps.details/components/application.component.ts
+++ b/src/client/app/flogo.apps.details/components/application.component.ts
@@ -155,8 +155,8 @@ export class FlogoApplicationComponent implements OnChanges, OnInit {
     this.flowSelected.emit(flow);
   }
 
-  onFlowDelete(flow){
-    this.flowDeleted.emit(flow);
+  onFlowDelete(eventData){
+    this.flowDeleted.emit(eventData);
   }
 
   onFlowImportSuccess(result: any) {

--- a/src/client/app/flogo.apps.details/components/container.component.ts
+++ b/src/client/app/flogo.apps.details/components/container.component.ts
@@ -2,13 +2,13 @@ import {Component, OnInit, OnDestroy} from '@angular/core';
 import { ActivatedRoute, Router, Params as RouteParams } from '@angular/router';
 import { TranslateService } from 'ng2-translate/ng2-translate';
 
-import { flogoIDEncode, notification } from '../../../common/utils';
+import { notification } from '../../../common/utils';
 import { PostService } from '../../../common/services/post.service'
 import { PUB_EVENTS as SUB_EVENTS } from '../../flogo.flows.add/message';
 import { AppDetailService, ApplicationDetail } from '../../flogo.apps/services/apps.service';
-import { FlowsService } from '../../flogo.apps/services/flows.service';
 
 import 'rxjs/add/operator/map';
+import {FlowsService} from "../../../common/services/flows.service";
 
 @Component({
   selector: 'flogo-app-container',
@@ -69,10 +69,12 @@ export class FlogoApplicationContainerComponent implements OnInit, OnDestroy {
     this.appService.reload();
   }
 
-  public onFlowDeleted(flow){
-    this.flowsService.deleteFlow(flow.id).then(()=>{
-      this.appService.reload();
-    });
+  public onFlowDeleted(eventData){
+    this.flowsService
+      .deleteFlowWithTrigger(eventData.flow.id, eventData.triggerId)
+      .then(() => {
+        this.appService.reload();
+      });
   }
 
   private initSubscribe() {

--- a/src/client/app/flogo.apps.flows/components/flow-group.component.ts
+++ b/src/client/app/flogo.apps.flows/components/flow-group.component.ts
@@ -16,8 +16,11 @@ export class FlowGroupComponent implements OnChanges {
   public trigger: Trigger;
   @Output()
   public flowSelected: EventEmitter<FlowModel> = new EventEmitter<FlowModel>();
-  @Output()
-  public deleteFlow: EventEmitter<FlowModel> = new EventEmitter<FlowModel>();
+  @Output() public deleteFlow: EventEmitter<{
+    triggerId: string, flow: FlowModel
+  }> = new EventEmitter<{
+    triggerId: string, flow: FlowModel
+  }>();
   @Output()
   public addFlow: EventEmitter<Trigger> = new EventEmitter<Trigger>();
 
@@ -39,7 +42,7 @@ export class FlowGroupComponent implements OnChanges {
   }
 
   onDeleteFlow(flow: FlowModel) {
-    this.deleteFlow.emit(flow);
+    this.deleteFlow.emit({triggerId: (this.trigger ? this.trigger.id : null), flow: flow});
   }
 
   onAddFlow() {

--- a/src/client/app/flogo.apps/flogo.apps.module.ts
+++ b/src/client/app/flogo.apps/flogo.apps.module.ts
@@ -17,7 +17,6 @@ import { FlogoAppDeletePopoverComponent } from '../flogo.apps.list/components/de
 import { FlogoApplicationSearch } from '../flogo.apps.search/components/search.component';
 
 import { AppDetailService } from './services/apps.service';
-import { FlowsService } from './services/flows.service';
 
 import {routing, appRoutingProviders} from './flogo.apps.routing';
 
@@ -44,8 +43,7 @@ import {routing, appRoutingProviders} from './flogo.apps.routing';
   bootstrap: [FlogoMainComponent],
   providers: [
     appRoutingProviders,
-    AppDetailService,
-    FlowsService,
+    AppDetailService
   ]
 })
 export class FlogoAppsModule {}

--- a/src/client/app/flogo.flows.detail/components/canvas.component.ts
+++ b/src/client/app/flogo.flows.detail/components/canvas.component.ts
@@ -145,7 +145,14 @@ export class FlogoCanvasComponent implements OnInit {
     this._flogoModal.confirmDelete(message)
       .then((res) => {
         if (res) {
-          this._flowService.deleteFlow(this.flowId)
+          let appPromise = null;
+          appPromise = (this.app) ? Promise.resolve(this.app) : this._restAPIAppsService.getApp(this.flow.app.id);
+
+          appPromise
+            .then((app) => {
+              let triggerDetails = this.getTriggerCurrentFlow(app, this.flow.id);
+              return this._flowService.deleteFlow(this.flowId, triggerDetails ? triggerDetails.id : null);
+            })
             .then(() => {
               this.navigateToApp();
             })
@@ -286,9 +293,9 @@ export class FlogoCanvasComponent implements OnInit {
   }
 
   private _getCurrentContext(taskId: any, diagramId: string) {
-    var isTrigger = this.handlers[diagramId].tasks[taskId].type === FLOGO_TASK_TYPE.TASK_ROOT;
-    var isBranch = this.handlers[diagramId].tasks[taskId].type === FLOGO_TASK_TYPE.TASK_BRANCH;
-    var isTask = this.handlers[diagramId].tasks[taskId].type === FLOGO_TASK_TYPE.TASK;
+    let isTrigger = this.handlers[diagramId].tasks[taskId].type === FLOGO_TASK_TYPE.TASK_ROOT;
+    let isBranch = this.handlers[diagramId].tasks[taskId].type === FLOGO_TASK_TYPE.TASK_BRANCH;
+    let isTask = this.handlers[diagramId].tasks[taskId].type === FLOGO_TASK_TYPE.TASK;
 
     return {
       isTrigger: isTrigger,
@@ -422,7 +429,7 @@ export class FlogoCanvasComponent implements OnInit {
 
   private getSettingsCurrentHandler () {
     let settings, outputs;
-    for(var key in this.flow.items) {
+    for(let key in this.flow.items) {
       if(this.flow.items[key].type === FLOGO_TASK_TYPE.TASK_ROOT) {
         settings = objectFromArray(this.flow.items[key].endpoint.settings, true);
         outputs = objectFromArray(this.flow.items[key].outputs, true);

--- a/src/client/app/flogo.flows.detail/services/flow.service.spec.ts
+++ b/src/client/app/flogo.flows.detail/services/flow.service.spec.ts
@@ -7,11 +7,14 @@ import {MockAPIFlowsService} from "../../../common/services/restapi/v2/flows-api
 import {MockBackend} from "@angular/http/testing";
 import {BaseRequestOptions, Http} from "@angular/http";
 import {HttpUtilsService} from "../../../common/services/restapi/http-utils.service";
+import {FlowsService} from "../../../common/services/flows.service";
 
 describe("Service: Flow", function(this: {
   service: FlogoFlowService,
   modelConverter: UIModelConverterService,
+  commonFlowsService: FlowsService,
   mockRESTAPI: MockAPIFlowsService,
+
   utilsService: HttpUtilsService
 }){
 
@@ -19,8 +22,11 @@ describe("Service: Flow", function(this: {
     this.modelConverter = jasmine.createSpyObj<UIModelConverterService>('converterService', [
       'getWebFlowModel'
     ]);
+    this.commonFlowsService = jasmine.createSpyObj<FlowsService>('commonFlowsService', [
+      'deleteFlowWithTrigger'
+    ]);
     this.mockRESTAPI = new MockAPIFlowsService(new Http(new MockBackend(), new BaseRequestOptions()), new HttpUtilsService());
-    this.service = new FlogoFlowService(this.mockRESTAPI, this.modelConverter);
+    this.service = new FlogoFlowService(this.mockRESTAPI, this.modelConverter, this.commonFlowsService);
   });
 
   it("Should get the Flow Details and convert it to work with canvas component", ()=>{

--- a/src/client/app/flogo.flows.detail/services/flow.service.ts
+++ b/src/client/app/flogo.flows.detail/services/flow.service.ts
@@ -5,6 +5,7 @@ import { flogoFlowToJSON } from "../../flogo.flows.detail.diagram/models/flow.mo
 import {IFlogoFlowDiagramTaskDictionary} from "../../flogo.flows.detail.diagram/models/dictionary.model";
 import {APIFlowsService} from "../../../common/services/restapi/v2/flows-api.service";
 import {  } from "../../../common/utils";
+import {FlowsService} from "../../../common/services/flows.service";
 
 interface FlowData {
   flow: any,
@@ -16,11 +17,13 @@ interface FlowData {
     diagram: any,
     tasks: any
   };
-};
+}
 
 @Injectable()
 export class FlogoFlowService {
-  constructor(private _flowAPIService: APIFlowsService, private _converterService: UIModelConverterService) {
+  constructor(private _flowAPIService: APIFlowsService,
+              private _converterService: UIModelConverterService,
+              private _commonFlowsService: FlowsService) {
   }
 
   getFlow(flowId: string): Promise<FlowData> {
@@ -52,8 +55,8 @@ export class FlogoFlowService {
     return this._flowAPIService.updateFlow(flowId, action);
   }
 
-  deleteFlow(flowId) {
-    return this._flowAPIService.deleteFlow(flowId);
+  deleteFlow(flowId, triggerId) {
+    return this._commonFlowsService.deleteFlowWithTrigger(flowId, triggerId);
   }
 
   listFlowsByName(appId, name) {

--- a/src/client/common/core.module.ts
+++ b/src/client/common/core.module.ts
@@ -20,6 +20,7 @@ import { LanguageService } from './services/language.service';
 import { ErrorService } from './services/error.service';
 import { WindowRef } from './services/window-ref';
 import { ChildWindowService } from './services/child-window.service';
+import {FlowsService} from "./services/flows.service";
 
 @NgModule({
   providers: [ // services
@@ -44,7 +45,8 @@ import { ChildWindowService } from './services/child-window.service';
     ConfigurationLoadedGuard,
     LoadingStatusService,
     LanguageService,
-    WindowRef
+    WindowRef,
+    FlowsService
   ]
 })
 export class CoreModule { }

--- a/src/client/common/services/flows.service.spec.ts
+++ b/src/client/common/services/flows.service.spec.ts
@@ -1,0 +1,96 @@
+import {FlowsService} from "./flows.service";
+import {RESTAPIHandlersService} from "./restapi/v2/handlers-api.service";
+import {APIFlowsService} from "./restapi/v2/flows-api.service";
+import {RESTAPITriggersService} from "./restapi/v2/triggers-api.service";
+import { RESTAPITriggersService as ContribTriggersService } from './restapi/triggers-api.service';
+
+import Spy = jasmine.Spy;
+import {ScalarObservable} from "rxjs/observable/ScalarObservable";
+
+describe("Service: FlowsService", function(this: {
+  testService: FlowsService,
+  mockHandlersAPIService: RESTAPIHandlersService,
+  mockTriggersService: RESTAPITriggersService,
+  mockContribTriggerAPIService: ContribTriggersService,
+  mockFlowsAPIService: APIFlowsService
+}){
+  let mockAppTriggerData = {
+    "name": "Receive HTTP Message",
+    "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/rest",
+    "description": "Simple REST Trigger",
+    "settings": {
+      "port": null
+    },
+    "id": "receive_http_message",
+    "createdAt": "2017-04-04T01:20:50.544Z",
+    "updatedAt": null,
+    "handlers": [
+      {
+        "settings": {
+          "method": "GET",
+          "path": null,
+          "autoIdReply": null,
+          "useReplyHandler": null
+        },
+        "actionId": "my_new_app"
+      },
+      {
+        "settings": {
+          "method": null,
+          "path": null,
+          "autoIdReply": null,
+          "useReplyHandler": null
+        },
+        "actionId": "app_with_trigger"
+      }
+    ],
+    "appId": "some_app_id_1"
+  }, spyDelete, spyDeleteTrigger;
+  beforeAll(() => {
+    this.mockContribTriggerAPIService = jasmine.createSpyObj<ContribTriggersService>('contribTriggersService', [
+      'getTriggerDetails'
+    ]);
+    this.mockFlowsAPIService = jasmine.createSpyObj<APIFlowsService>('flowsAPIService', [
+      'deleteFlow'
+    ]);
+    this.mockTriggersService = jasmine.createSpyObj('triggersService',[
+      'getTrigger',
+      'deleteTrigger'
+    ]);
+    this.mockHandlersAPIService = jasmine.createSpyObj<RESTAPIHandlersService>('handlersAPIService', [
+      'updateHandler'
+    ]);
+    this.testService = new FlowsService(this.mockHandlersAPIService, this.mockFlowsAPIService,
+      this.mockTriggersService, this.mockContribTriggerAPIService);
+    spyDelete = <Spy> this.mockFlowsAPIService.deleteFlow;
+    spyDelete.and.returnValue(Promise.resolve({}));
+    spyDeleteTrigger = <Spy> this.mockTriggersService.deleteTrigger;
+    spyDeleteTrigger.and.returnValue(Promise.resolve({}));
+  });
+
+  it('Should delete only the flow but not the Trigger', (done)=>{
+    let specTriggerData = _.assign({}, mockAppTriggerData);
+    specTriggerData.handlers.pop();
+    let spyGetTrigger = <Spy> this.mockTriggersService.getTrigger;
+    spyGetTrigger.and.returnValue(Promise.resolve(specTriggerData));
+    this.testService.deleteFlowWithTrigger('some_flow_id_1', 'some_trigger_id_1')
+      .then((data)=>{
+        expect(_.isEqual(data,{})).toEqual(true);
+        done();
+      });
+  });
+
+  it('Should delete and also the Trigger', (done)=>{
+    let specTriggerData = _.assign({}, mockAppTriggerData);
+    specTriggerData.handlers.pop();
+    specTriggerData.handlers.pop();
+    let spyGetTrigger = <Spy> this.mockTriggersService.getTrigger;
+    spyGetTrigger.and.returnValue(Promise.resolve(specTriggerData));
+    this.testService.deleteFlowWithTrigger('some_flow_id_2', 'some_trigger_id_2')
+      .then((data)=>{
+        expect(_.isEqual(data,{})).toEqual(true);
+        expect(spyDeleteTrigger).toHaveBeenCalledTimes(1);
+        done();
+      });
+  });
+});

--- a/src/client/common/services/flows.service.ts
+++ b/src/client/common/services/flows.service.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from "@angular/core";
+import {objectFromArray} from "../utils";
 
-import { RESTAPIHandlersService as HandlersService } from '../../../common/services/restapi/v2/handlers-api.service';
-import { APIFlowsService as FlowsApiService } from '../../../common/services/restapi/v2/flows-api.service';
-import { RESTAPITriggersService as TriggersService } from '../../../common/services/restapi/v2/triggers-api.service';
-import { RESTAPITriggersService as ContribTriggersService } from '../../../common/services/restapi/triggers-api.service';
-import { objectFromArray } from '../../../common/utils';
+import { RESTAPIHandlersService as HandlersService } from './restapi/v2/handlers-api.service';
+import { APIFlowsService as FlowsApiService } from './restapi/v2/flows-api.service';
+import { RESTAPITriggersService as TriggersService } from './restapi/v2/triggers-api.service';
+import { RESTAPITriggersService as ContribTriggersService } from './restapi/triggers-api.service';
 
 @Injectable()
 export class FlowsService {
@@ -30,8 +30,27 @@ export class FlowsService {
       })
   }
 
-  public deleteFlow(flowId) {
+  deleteFlow(flowId) {
     return this.flowsService.deleteFlow(flowId);
+  }
+
+  deleteFlowWithTrigger(flowId: string, triggerId: string) {
+    return this.deleteFlow(flowId)
+      .then(() => {
+        if(triggerId){
+          return this.triggersService.getTrigger(triggerId)
+            .then(triggerDetails => {
+              if(triggerDetails.handlers.length === 0) {
+                return this.triggersService.deleteTrigger(triggerDetails.id);
+              } else {
+                return {};
+              }
+            });
+        } else {
+          return {};
+        }
+      })
+      .catch((err) => Promise.reject(err));
   }
 
   private getContribInfo(triggerInstanceId) {

--- a/src/client/common/services/restapi/v2/triggers-api.service.ts
+++ b/src/client/common/services/restapi/v2/triggers-api.service.ts
@@ -38,6 +38,10 @@ export class  RESTAPITriggersService {
       .catch(error => Promise.reject(this.extractErrors(error)));
   }
 
+  deleteTrigger(triggerId: string) {
+    return this.http.delete(`/api/v2/triggers/${triggerId}`).toPromise();
+  }
+
   private extractData(res: Response) {
     let body = res.json();
     // todo: body.data won't always be an object, could be an array


### PR DESCRIPTION
Fixes #387 - Implemented the feature where we are deleting the trigger if there are no more flows associated to it.

Altered the deleteFlowWithTrigger method to accept triggerId instead of whole trigger object

Removed the deleteTrigger boolean parameter check while deleting the Trigger

Avoid returning unnecessary Promises

Added test case for Delete along with trigger method of Flows service

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently after deleting the flows of an application, we are not deleting the triggers which are not associated with any flow. This will increase in the inaccessible triggers in an application.


**What is the new behavior?**
We are now deleting the trigger if we are deleting the last flow associated to that trigger in an application.

**Other information**:
