### PR TITLE
The Trigger rename will no longer adds (2) always - #399

### DIFF
--- a/src/client/app/flogo.flows.detail/components/canvas.component.ts
+++ b/src/client/app/flogo.flows.detail/components/canvas.component.ts
@@ -265,12 +265,22 @@ export class FlogoCanvasComponent implements OnInit {
 
   }
 
-  private uniqueTaskName(taskName: string) {
+  private uniqueTaskName(taskName: string, isTrigger?: boolean) {
     // TODO for performance pre-normalize and store task names?
     let newNormalizedName = normalizeTaskName(taskName);
 
     //All activities are gathered in one variable
     let allTasks = _.reduce(this.handlers, (all: any, current: any) => _.assign(all, current.tasks), {});
+
+    if(isTrigger){
+      let allTriggers = _.reduce(this.app.triggers, (all:any, current: any, index:number) => {
+        if(this.currentTrigger.id != current.id){
+          all['trigger'+index] = current;
+        }
+        return all;
+      }, {});
+      allTasks = _.assign({},allTasks,allTriggers);
+    }
 
     //search for the greatest index in all the flow
     let greatestIndex = _.reduce(allTasks, (greatest: number, task: any) => {
@@ -697,7 +707,7 @@ export class FlogoCanvasComponent implements OnInit {
             .then((app) => {
               // Refresh task detail
               var currentStep = this._getCurrentState(data.node.taskID);
-              var currentTask = this.handlers[diagramId].tasks[data.node.taskID];
+              var currentTask = _.assign({}, _.cloneDeep(this.handlers[diagramId].tasks[data.node.taskID]));
               var context = this._getCurrentContext(data.node.taskID, diagramId);
 
               if(!this.currentTrigger) {
@@ -828,7 +838,7 @@ export class FlogoCanvasComponent implements OnInit {
 
     if (task) {
       if (data.proper == 'name') {
-        task[data.proper] = this.uniqueTaskName(data.content);
+        task[data.proper] = this.uniqueTaskName(data.content, task.type === FLOGO_TASK_TYPE.TASK_ROOT);
       } else {
         task[data.proper] = data.content;
       }


### PR DESCRIPTION
Fixes #399 - Modified the code to send the cloned data of trigger to details component rather than the reference of the object from canvas component's handler.

In case of Triggers, the uniqueTaskName method in canvas component will also consider the trigger names available in the application.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently when I change a trigger name, it always adds a **(2)** as if its name is already taken though it is not.


**What is the new behavior?**
Now it will check the trigger name is unique among the names within the flow as well as the triggers of the application.