### PR TITLE
Reintroduced the error icon which is lost with changes to Steps service call - #314

### DIFF
--- a/src/client/app/flogo.flows.detail/components/canvas.component.ts
+++ b/src/client/app/flogo.flows.detail/components/canvas.component.ts
@@ -1442,26 +1442,26 @@ export class FlogoCanvasComponent implements OnInit {
 
         taskID = flogoIDEncode('' + taskID);
         runTasksIDs.push(taskID);
-        let reAttrName = new RegExp(`^\\[A${step.taskId}\\..*`, 'g');
-        let reAttrErrMsg = new RegExp(`^\\[A${step.taskId}\\._errorMsg\\]$`, 'g');
+        let reAttrName = new RegExp(`^\{A${step.taskId}\\..*`, 'g');
+        let reAttrErrMsg = new RegExp(`^\{Error.message}`, 'g');
 
         let taskInfo = _.reduce(_.get(step, 'flow.attributes', []), (taskInfo: any, attr: any) => {
           if (reAttrName.test(_.get(attr, 'name', ''))) {
             taskInfo[attr.name] = attr;
+          }
 
-            if (reAttrErrMsg.test(attr.name)) {
-              let errs = <any[]>_.get(errors, `${taskID}`);
-              let shouldOverride = _.isUndefined(errs);
-              errs = errs || [];
+          if (reAttrErrMsg.test(attr.name)) {
+            let errs = <any[]>_.get(errors, `${taskID}`);
+            let shouldOverride = _.isUndefined(errs);
+            errs = errs || [];
 
-              errs.push({
-                msg: attr.value,
-                time: new Date().toJSON()
-              });
+            errs.push({
+              msg: attr.value,
+              time: new Date().toJSON()
+            });
 
-              if (shouldOverride) {
-                _.set(errors, `${taskID}`, errs);
-              }
+            if (shouldOverride) {
+              _.set(errors, `${taskID}`, errs);
             }
           }
           return taskInfo;


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When a tile is breaking the test run of a flow, we do not show an error icon on top of the tile and show the error message description due to which the error is raised.


**What is the new behavior?**
We now show the error icon and message on top of the tile (activity) due to which the flow's test run is failed. 

**Other information**:
