### PR TITLE
Fix momentary issue with missing labels in flow details page

### DIFF
--- a/src/client/app/flogo.flows.detail.diagram/components/diagram.component.less
+++ b/src/client/app/flogo.flows.detail.diagram/components/diagram.component.less
@@ -2,27 +2,6 @@
 @color-error: @color-danger;
 @color-error--selected: #a23746;
 
-@font-face{
-  font-family: SourceSansPro-Regular;
-  src: url('/assets/fonts/SourceSansPro-Regular.ttf'),
-  url('/assets/fonts/SourceSansPro-Regular.eot');
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face{
-  font-family: SourceSansPro-Bold;
-  src: url('/assets/fonts/SourceSansPro-Bold.ttf'),
-  url('/assets/fonts/SourceSansPro-Bold.eot');
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face{
-  font-family: SourceSansPro-Semibold;
-  src: url('/assets/fonts/SourceSansPro-Semibold.ttf');
-  font-weight: normal;
-  font-style: normal;
-}
-
 @diagram-node-height: 112px;
 @diagram-placeholder-node-height: 70px;
 @diagram-row-height: 140px;
@@ -79,7 +58,7 @@
 
   white-space: normal;
 
-  font-family: SourceSansPro-Regular;
+  font-family: 'SourceSansPro-Regular';
   font-size: @diagram-node-font-size-large;
   line-height: 1;
   letter-spacing: 1px;
@@ -135,7 +114,7 @@
 
     &.flogo-flows-detail-diagram-node-has-warn {
       .flogo-flows-detail-diagram-node-detail-description {
-        font-family: SourceSansPro-Regular;
+        font-family: 'SourceSansPro-Regular';
         font-size: @diagram-node-font-size-small;
         color: #fff;
       }
@@ -351,7 +330,7 @@
   }
 
   .flogo-flows-detail-diagram-node-detail-title{
-    font-family: SourceSansPro-Bold;
+    font-family: 'SourceSansPro-Bold';
     font-weight: 600;
     padding-bottom: 10px;
     letter-spacing: .4px;
@@ -372,7 +351,7 @@
   }
   &.flogo-flows-detail-diagram-node-has-warn {
     .flogo-flows-detail-diagram-node-detail-description {
-      font-family: SourceSansPro-Semibold;
+      font-family: 'SourceSansPro-Semibold';
       font-size: 11px;
       color: #ff9f00;
     }

--- a/src/client/assets/main.less
+++ b/src/client/assets/main.less
@@ -55,6 +55,29 @@ body {
   font-weight: 300;
 }
 
+@font-face{
+  font-family: 'SourceSansPro-Regular';
+  src: url('fonts/SourceSansPro-Regular.eot');
+  src: url('fonts/SourceSansPro-Regular.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face{
+  font-family: 'SourceSansPro-Bold';
+  src: url('fonts/SourceSansPro-Bold.eot');
+  src: url('fonts/SourceSansPro-Bold.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face{
+  font-family: 'SourceSansPro-Semibold';
+  src: url('fonts/SourceSansPro-Semibold.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
 /* Set up a default font and some padding to provide breathing room */
 body {
   font-family: 'Source Sans Pro', sans-serif;


### PR DESCRIPTION
Fixes #401 - adjusted the problem with font face definition and fix the momentary issue of hiding the labels/texts in UI because of it

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The first time when the flow details page loads after a fresh build, the labels are not displayed in the page


**What is the new behavior?**
Now the flow details page will show the labels even if it is launched for the first time after the build

**Other information**:
