### PR TITLE
Selecting the app will always launch the app details page - #419

### DIFF
--- a/src/client/app/flogo.apps.details/components/container.component.ts
+++ b/src/client/app/flogo.apps.details/components/container.component.ts
@@ -9,6 +9,7 @@ import { AppDetailService, ApplicationDetail } from '../../flogo.apps/services/a
 
 import 'rxjs/add/operator/map';
 import {FlowsService} from "../../../common/services/flows.service";
+import {Subscription} from "rxjs/Subscription";
 
 @Component({
   selector: 'flogo-app-container',
@@ -19,6 +20,7 @@ import {FlowsService} from "../../../common/services/flows.service";
 export class FlogoApplicationContainerComponent implements OnInit, OnDestroy {
   public appDetail: ApplicationDetail = null;
   private subscriptions: any;
+  private appObserverSubscription: Subscription;
 
   constructor(
     public translate: TranslateService,
@@ -38,7 +40,7 @@ export class FlogoApplicationContainerComponent implements OnInit, OnDestroy {
         this.appService.load(appId);
       });
 
-    this.appService.currentApp()
+    this.appObserverSubscription = this.appService.currentApp()
       .subscribe((appDetail: ApplicationDetail) => {
         if (!appDetail) {
           // not initialized yet
@@ -54,6 +56,10 @@ export class FlogoApplicationContainerComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy() {
+    // Unsubscribe the subscription on currentApp's observable object created in this instance of container component
+    this.appObserverSubscription.unsubscribe();
+    // Reset currentApp$ next element to null
+    this.appService.resetApp();
     // cancel subscriptions
     _.each(this.subscriptions, sub => {
         this.postService.unsubscribe(sub);

--- a/src/client/app/flogo.apps/services/apps.service.ts
+++ b/src/client/app/flogo.apps/services/apps.service.ts
@@ -60,6 +60,10 @@ export class AppDetailService {
     return this.currentApp$.asObservable();
   }
 
+  public resetApp() {
+    this.currentApp$.next(null);
+  }
+
   public load(appId: string) {
     this.fetchApp(appId).then(app => {
       this.currentApp$.next(<ApplicationDetail>_.defaultsDeep({}, {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently when we delete the application from application details page and try to select another application / create a new application, the page tries to launch the application details page and redirects back to landing page.


**What is the new behavior?**
Now irrespective of the scenario, the selection of application always launches application details page.