### PR TITLE
406 - Changing the tile name of a flow maintains the same name in diagram and task details

### DIFF
--- a/src/client/app/flogo.flows.detail/components/canvas.component.ts
+++ b/src/client/app/flogo.flows.detail/components/canvas.component.ts
@@ -34,6 +34,10 @@ import { FlogoModal } from '../../../common/services/modal.service';
 import { HandlerInfo } from '../models/models';
 import { FlogoFlowService as FlowsService } from '../services/flow.service';
 
+interface IPropsToUpdateFormBuilder {
+  name: string;
+}
+
 @Component({
   selector: 'flogo-canvas',
   // moduleId: module.id,
@@ -834,8 +838,19 @@ export class FlogoCanvasComponent implements OnInit {
       }
       let updateObject = {};
 
+      let propsToUpdateFormBuilder: IPropsToUpdateFormBuilder = <IPropsToUpdateFormBuilder> {};
+
+      propsToUpdateFormBuilder.name = task.name;
+
       this._updateFlow(this.flow).then(() => {
         this._postService.publish(FLOGO_DIAGRAM_PUB_EVENTS.render);
+        this._postService.publish(
+          _.assign(
+            {}, FLOGO_TASK_PUB_EVENTS.updatePropertiesToFormBuilder, {
+              data: propsToUpdateFormBuilder
+            }
+          )
+        );
       });
 
       if(task.type === FLOGO_TASK_TYPE.TASK_ROOT) {

--- a/src/client/app/flogo.form-builder/components/form-builder.component.ts
+++ b/src/client/app/flogo.form-builder/components/form-builder.component.ts
@@ -1,7 +1,7 @@
 import { Component, Output, EventEmitter } from '@angular/core';
 import { PostService} from '../../../common/services/post.service';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
-import { PUB_EVENTS } from '../messages';
+import { PUB_EVENTS, SUB_EVENTS } from '../messages';
 import { FLOGO_ERROR_ROOT_NAME } from '../../../common/constants';
 import { convertTaskID, normalizeTaskName, getDefaultValue } from "../../../common/utils";
 import { TranslateService } from 'ng2-translate/ng2-translate';
@@ -54,10 +54,11 @@ export class FlogoFormBuilderComponent{
 
   private _initSubscribe() {
     this._subscriptions = [];
-    //let subs :any[] = [];
+    let subs = [
+      _.assign({}, SUB_EVENTS.updatePropertiesToFormBuilder, {callback: this._updatePropertiesToFormBuilder.bind(this)})
+    ];
 
-    _.each(
-      (subs:any, sub:any) => {
+    _.each(subs, (sub:any) => {
         this._subscriptions.push( this._postService.subscribe( sub ) );
       }
     );
@@ -569,5 +570,9 @@ export class FlogoFormBuilderComponent{
         }
       } );
     return condition;
+  }
+
+  _updatePropertiesToFormBuilder(data: any, envelope: any) {
+    this._task.name = data.name;
   }
 }

--- a/src/client/app/flogo.form-builder/messages.ts
+++ b/src/client/app/flogo.form-builder/messages.ts
@@ -29,8 +29,8 @@ export const PUB_EVENTS = {
  * Events subscribed by this module
  */
 export const SUB_EVENTS = {
-  updateTaskResults: {
+  updatePropertiesToFormBuilder: {
     channel: 'flogo-task',
-    topic: 'update-task-results'
+    topic: 'update-properties-form-builder'
   }
 };


### PR DESCRIPTION
Fixes #406 - Publishing updateTileName message after updating the flow details in canvas component

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
As per #406 , if we change the name of the task same as any other task name, we implement the uniqueness from code by adding a (2) or (3) or so on to the name. But the modification done to the task name to get the uniqueness only is displayed in the Flow Diagram but not reflected in Task details view (right hand side of the page).


**What is the new behavior?**
Now if the name of task undergoes uniqueness and get a modified name, then it will be also reflected in the task details view (right hand side of the page).