### PR TITLE
Replaced code to use activityRef instead of ref for finding Reply to Trigger activity- #430

### DIFF
--- a/src/client/app/flogo.flows.detail.diagram/models/flow.model.ts
+++ b/src/client/app/flogo.flows.detail.diagram/models/flow.model.ts
@@ -568,7 +568,7 @@ export function flogoFlowToJSON( inFlow : flowToJSON_InputFlow ) : flowToJSON_Fl
 
     // hardcoding the activity type, for now
     // TODO: maybe the activity should expose a property so we know it can reply?
-    return !!_.find(tasks, task => (<any>task).ref == 'github.com/TIBCOSoftware/flogo-contrib/activity/reply');
+    return !!_.find(tasks, task => (<any>task).activityRef == 'github.com/TIBCOSoftware/flogo-contrib/activity/reply');
 
   }
 

--- a/src/server/modules/apps/index.v2.js
+++ b/src/server/modules/apps/index.v2.js
@@ -1,4 +1,5 @@
 import pick from 'lodash/pick';
+import get from 'lodash/get';
 import defaults from 'lodash/defaults';
 import fromPairs from 'lodash/fromPairs';
 import isEqual from 'lodash/isEqual';
@@ -261,6 +262,14 @@ export class AppsManager {
         // convert orphan actions ids
         actionMap.forEach(a => {
           a.id = normalizeName(a.name);
+        });
+
+        app.actions.forEach(action => {
+          const tasks = get(action, 'data.flow.rootTask.tasks', []);
+          const hasExplicitReply = tasks.find(t => t.activityRef === 'github.com/TIBCOSoftware/flogo-contrib/activity/reply');
+          if (hasExplicitReply) {
+            action.data.flow.explicitReply = true;
+          }
         });
 
         if(!app.version) {


### PR DESCRIPTION
Reintroduced missing explicitReply property set to true which is required to be added to the flow data when the flow contains the "Reply to Trigger" activity.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The application build / exported which has a flow containing a "Reply to Trigger" activity does not respond as per the Reply to Trigger activity

**What is the new behavior?**
The Application which are built from UI has flows containing Reply to Trigger activity works as expected.