### PR TITLE
Reintroduced the trigger-installed custom validation in ajv - #413 and #414

### DIFF
--- a/src/server/modules/apps/import.v2.js
+++ b/src/server/modules/apps/import.v2.js
@@ -1,7 +1,4 @@
 import cloneDeep from 'lodash/cloneDeep';
-import isArray from 'lodash/isArray';
-import isObject from 'lodash/isObject';
-import get from 'lodash/get';
 
 import { ErrorManager, ERROR_TYPES } from '../../common/errors';
 import { Validator } from './validator';
@@ -17,7 +14,7 @@ import { TriggerManager as ContribTriggersManager } from '../triggers';
 export function importApp(fromApp) {
   const clonedApp = cloneDeep(fromApp);
   // TODO: apply unique names to tasks
-  return getInstalledActivitiesAndTriggers(fromApp)
+  return getInstalledActivitiesAndTriggers()
     .then(installedContribs => {
       const errors = Validator.validateFullApp(clonedApp, installedContribs,
         { removeAdditional: true, useDefaults: true });
@@ -72,14 +69,16 @@ function chainPromises(from, thenDo) {
   return from.reduce((promiseChain, e) => promiseChain.then(() => thenDo(e)), Promise.resolve(true));
 }
 
-function getInstalledActivitiesAndTriggers(app) {
-  const allRefs = extractRefs(app);
+function getInstalledActivitiesAndTriggers() {
   const mapRefs = contribs => contribs.map(c => c.ref);
   return Promise.all([
-    ContribTriggersManager.find(allRefs.triggers).then(mapRefs),
-    ContribActivitiesManager.find(mapRefs).then(mapRefs),
+    ContribTriggersManager.find().then(mapRefs),
+    ContribActivitiesManager.find().then(mapRefs),
   ]).then(([triggers, activities]) => ({ triggers, activities }));
 }
+/*
+
+It is not used for the time being as our activities contribution fetching api's do not have activityRef
 
 export function extractRefs(app) {
   const allRefs = { triggers: [], activities: [] };
@@ -106,4 +105,4 @@ export function extractRefs(app) {
   });
   allRefs.activities = Array.from(activityRefMap.keys());
   return allRefs;
-}
+}*/

--- a/src/server/modules/apps/validator.js
+++ b/src/server/modules/apps/validator.js
@@ -203,7 +203,7 @@ function fullAppSchema() {
             },
             ref: {
               type: 'string',
-              'x-trigger-installed': true,
+              'trigger-installed': true,
             },
             name: {
               type: 'string',


### PR DESCRIPTION
Fixes #413  and Fixes #414 - Re-implemented the trigger-installed custom validation in ajv.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When we try to import an application JSON which has a trigger ref not installed in flogo-web engine, the validation error triggers but with an error object which is not consistent with the other validation errors. Also the application is created with empty flows. 


**What is the new behavior?**
The trigger-installed ajv custom validation was inactive and the same is reintroduced. The Trigger not installed message is now similar to the way the other validation errors work and we are able to see the Trigger missing error message along with other ajv validation errors in flogo-web. Also avoiding the application creation when the trigger-installed validation error occurs.