### PR TITLE
#470 - A new device setting in Other category is not added when we cl…

### DIFF
--- a/src/client/app/flogo.apps.settings/components/settings.component.ts
+++ b/src/client/app/flogo.apps.settings/components/settings.component.ts
@@ -88,9 +88,8 @@ export class FlogoAppSettingsComponent {
   public saveChanges() {
     const otherSettings = {};
     const input =  this.inputSettings.filter((input) => input.key !== OTHER_CATEGORY);
-
+    this.addCustom();
     this.customSettings.forEach((setting) => otherSettings[setting.key] =  setting.value);
-
     const databaseFormat = serializeSettings(input.concat([{key: OTHER_CATEGORY, settings: otherSettings}]));
     this.save.emit(databaseFormat);
     this.closeModal();


### PR DESCRIPTION
…ick on save changes

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When tried to add a new key under Other category using save button, won't add it to the device settings. But it is saved when  clicked on the + button.


**What is the new behavior?**
The settings under the other category is getting added to the device settings when Save button is clicked on modal window.

**Other information**:
