### PR TITLE
Disable multiple triggers for device profile in case of empty flow state

### DIFF
--- a/src/client/app/flogo.flows.detail.triggers-panel/components/triggers-panel.component.ts
+++ b/src/client/app/flogo.flows.detail.triggers-panel/components/triggers-panel.component.ts
@@ -159,6 +159,7 @@ export class FlogoFlowTriggersPanelComponent implements OnInit, OnChanges, OnDes
           this.triggers.push(trigger);
         }
         this.makeTriggersListForAction();
+        this.manageAddTriggerInView();
     });
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
In case of an empty (/new) flow state, a user can add more than one trigger for device profile. A device profile cannot have more than one trigger assigned to a flow.


**What is the new behavior?**
The "Add trigger" button should be disabled once the user add a trigger to the action