### PR TITLE
Enable use of flow inputs in task mapper.

### DIFF
--- a/src/client/app/flogo.transform/messages.ts
+++ b/src/client/app/flogo.transform/messages.ts
@@ -1,6 +1,7 @@
 /**
  * Events published from this module
  */
+import { IFlogoFlowDiagramTask } from '../flogo.flows.detail.diagram/models/task.model';
 
 export const PUB_EVENTS = {
   selectActivity : {
@@ -34,3 +35,11 @@ export const SUB_EVENTS = {
     topic : 'public-delete-transform'
   }
 };
+
+export interface SelectTaskData {
+  handlerId: string;
+  // scope
+  scope: any[];
+  tile: IFlogoFlowDiagramTask;
+}
+

--- a/src/client/app/flogo.transform/models/flow-metadata.ts
+++ b/src/client/app/flogo.transform/models/flow-metadata.ts
@@ -1,0 +1,5 @@
+export interface FlowMetadata {
+  type: 'metadata';
+  input: Array<{ name: string; type: string; }>;
+  output: Array<{ name: string; type: string; }>;
+}

--- a/src/client/app/flogo.transform/models/index.ts
+++ b/src/client/app/flogo.transform/models/index.ts
@@ -1,0 +1,2 @@
+export * from './mapper-schema';
+export * from './flow-metadata';

--- a/src/client/app/flogo.transform/models/mapper-schema.ts
+++ b/src/client/app/flogo.transform/models/mapper-schema.ts
@@ -1,0 +1,7 @@
+export interface MapperSchema {
+  type: string;
+  properties: {[name: string]: { type: string }};
+  required?: string[];
+  title?: string;
+  rootType?: string;
+}

--- a/src/client/app/flogo.transform/transform.component.spec.ts
+++ b/src/client/app/flogo.transform/transform.component.spec.ts
@@ -79,7 +79,7 @@ describe('Component: TransformComponent', () => {
   function getMockData() {
 
     return {
-      'previousTiles': [
+      scope: [
         {
           'type': 0,
           'triggerType': 'tibco-timer',
@@ -162,7 +162,7 @@ describe('Component: TransformComponent', () => {
           'id': 'Mg'
         }
       ],
-      'tile': {
+      tile: {
         'type': 1,
         'activityType': 'tibco-log',
         'name': 'Logger',
@@ -203,7 +203,7 @@ describe('Component: TransformComponent', () => {
         ],
         'id': 'Mw'
       },
-      'id': 'root'
+      handlerId: 'root'
     };
   }
 

--- a/src/client/app/flogo.transform/transform.component.ts
+++ b/src/client/app/flogo.transform/transform.component.ts
@@ -7,7 +7,7 @@ import {
 
 import { PostService } from '../../common/services/post.service';
 
-import { PUB_EVENTS, SUB_EVENTS } from './messages';
+import { PUB_EVENTS, SUB_EVENTS, SelectTaskData } from './messages';
 
 import { IMapping, IMapExpression } from '../flogo.mapper/models/map-model';
 import { IFlogoFlowDiagramTask } from '../flogo.flows.detail.diagram/models/task.model';
@@ -144,24 +144,20 @@ export class TransformComponent implements OnDestroy {
     return true;
   }
 
-  private initTransformation(data: {
-    id: string,
-    previousTiles: IFlogoFlowDiagramTask[],
-    tile: IFlogoFlowDiagramTask
-  }, envelope: any) {
-    if (!this.raisedByThisDiagram(data.id)) {
+  private initTransformation(data: SelectTaskData, envelope: any) {
+    if (!this.raisedByThisDiagram(data.handlerId)) {
       return;
     }
     this.currentTile = data.tile;
     this.resetState();
-    this.mapperContext = this.createContext(data.tile, data.previousTiles);
+    this.mapperContext = this.createContext(data.tile, data.scope);
     this.open();
   }
 
   // todo: get data from event
-  private createContext(inputTile: IFlogoFlowDiagramTask, outputTiles: IFlogoFlowDiagramTask[]) {
+  private createContext(inputTile: IFlogoFlowDiagramTask, scope: IFlogoFlowDiagramTask[]) {
     const inputSchema = MapperTranslator.createInputSchema(inputTile);
-    const outputSchema = MapperTranslator.createOutputSchema(outputTiles);
+    const outputSchema = MapperTranslator.createOutputSchema(scope);
     const mappings = MapperTranslator.translateMappingsIn(inputTile.inputMappings);
     return MapperContextFactory.create(inputSchema, outputSchema, mappings);
   }


### PR DESCRIPTION
Enable use of input data from flow's metadata in the tasks mapper.

Click on "transform" over an activity and when mapper opens the flow input metadata is available to use.

Fixes #527
