### PR TITLE
Quick fix - Reintroduce Edit icon in trigger details 

### DIFF
--- a/src/client/app/flogo.form-builder.configuration.trigger/components/form-builder.configuration.trigger.less
+++ b/src/client/app/flogo.form-builder.configuration.trigger/components/form-builder.configuration.trigger.less
@@ -1,3 +1,7 @@
+.flogo-icon-edit {
+  font-size: 14px;
+}
+
 .settings__menu {
   color: #676a6d;
   position: absolute;
@@ -39,6 +43,11 @@
         }
         &:hover {
           color: #79b8dc;
+        }
+
+        .flogo-icon-edit {
+          font-size: 11px;
+          padding-top: 3px;
         }
       }
 

--- a/src/client/app/flogo.form-builder.configuration.trigger/components/form-builder.configuration.trigger.tpl.html
+++ b/src/client/app/flogo.form-builder.configuration.trigger/components/form-builder.configuration.trigger.tpl.html
@@ -5,7 +5,7 @@
       <h3 class="flogo-common-edit-panel__legend">{{ 'FORM-BUILDER-CONFIGURATION-TRIGGER:SETTINGS' | translate }}</h3>
 
       <div class="settings__menu" *ngIf="needEditConfirmation">
-        <i class="flogo-icon-kebabmenu"></i>
+        <i class="flogo-icon-edit"></i>
         <div class="settings__menu__options">
           <ul class="settings__menu__options__list">
             <li class="settings__menu__options__list__element" (click)="clickEditForNFlows($event)">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
As the `flogo-icon-edit` was missed earlier when the fonticons where modified last time, the icon is replaced with a kebab menu icon against a trigger's settings when it has more than 1 handlers associated with it. 

![image](https://user-images.githubusercontent.com/23206463/31434150-300268e8-ae99-11e7-9c71-5487afeabaf5.png)


**What is the new behavior?**
The kebab menu is replaced with the original edit icon and as per the [design](https://app.zeplin.io/project/56f4413010632c0e625223e4/screen/58d2e601f6dbc258d8aab05f ) as follows:

![image](https://user-images.githubusercontent.com/23206463/31434119-172d3a5a-ae99-11e7-9e2b-95a56f8e9012.png)


**Other information**:
