### PR TITLE
App details - Flows are now listed under more than one trigger

### DIFF
--- a/src/client/app/flogo.apps/services/apps.service.ts
+++ b/src/client/app/flogo.apps/services/apps.service.ts
@@ -182,13 +182,16 @@ export class AppDetailService {
   }
 
   private makeFlowGroups(triggers, actions): FlowGroup[] {
+    let handlers = [];
+    triggers.forEach(t => {
+      handlers = handlers.concat(t.handlers);
+    });
+    const orphanActions = actions.filter(a => !handlers.find(h => h.actionId === a.id));
+    const orphanActionMap = new Map(<[string, any][]> orphanActions.map(a => [a.id, a]));
     const actionMap = new Map(<[string, any][]> actions.map(a => [a.id, a]));
 
     const pullAction = actionId => {
       const action = actionMap.get(actionId);
-      if (action) {
-        actionMap.delete(actionId);
-      }
       return action;
     };
 
@@ -202,10 +205,10 @@ export class AppDetailService {
     }).filter(triggerGroup => triggerGroup.flows.length > 0);
 
     // orphan flows
-    if (actionMap.size) {
+    if (orphanActionMap.size) {
       triggerGroups.unshift({
         trigger: null,
-        flows: Array.from(actionMap.values()),
+        flows: Array.from(orphanActionMap.values()),
       });
     }
 


### PR DESCRIPTION
Same flow is now listed in more than one trigger when it has multiple triggers associated to it

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
After implementing multiple triggers support for flows, in application details page, if a flow has more than one trigger then it is shown only once under the first trigger it finds the mapping for


**What is the new behavior?**
Now the same trigger is listed under multiple triggers when it is has multiple triggers associated with it