### PR TITLE
quick-fix - Add Trigger does not launch the modal the second time

### DIFF
--- a/src/client/app/flogo.select-trigger/components/select-trigger.component.ts
+++ b/src/client/app/flogo.select-trigger/components/select-trigger.component.ts
@@ -25,7 +25,7 @@ export class FlogoSelectTriggerComponent implements OnInit, OnChanges {
   public displayExisting: boolean;
 
   public existingTriggers = [];
-  private _isActivated: boolean;
+  private _isActivated = false;
 
 
   constructor(public translate: TranslateService,


### PR DESCRIPTION
Fixing the bug where the add trigger modal won't fire when we dismiss the modal using the 'onDismiss' event

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When we launch the **add trigger** modal the first time and dismiss it by pressing **ESC** key or by clicking anywhere outside the modal, The **add trigger** modal won't fire up from the next time until user revisits the flow designer page


**What is the new behavior?**
The user will be able to launch the **add trigger** modal even from the second attempt as per the above scenario. It was happening because the modal.close() method is invoked while initializing the **select-trigger.component** even before the modal is open or not. When the user opens the modal the first time, the modal opens but does not fire the **onDismiss** event even though the modal is dismissed. Which does not reset the flag **showAddTrigger** in **triggers-panel.component** and always set to **true**. When user try to launch the modal the second time, the flag's value is not changed which won't change the input parameter **(isActivated)** of **select-trigger.component** and the modal does not open.