### PR TITLE
Fix alignment issue of the menu icon on hover

### DIFF
--- a/src/client/app/flogo.flows.detail/run-flow/run-flow.component.less
+++ b/src/client/app/flogo.flows.detail/run-flow/run-flow.component.less
@@ -19,10 +19,13 @@
   position: relative;
 }
 
+.flogo-button {
+  width: 125px;
+  margin-left: 0.5em;
+}
+
 .run-flow__button {
-  margin: 0 0.5em;
-  width: 124px;
-  height: 35px;
+  margin: 0 0.5em 0 0;
 
   &.--disabled {
     cursor: not-allowed;
@@ -61,9 +64,4 @@
 .button__container {
   text-align: right;
   margin-top: 1.25em;
-}
-
-.flogo-button {
-  width: 125px;
-  margin-left: 0.5em;
 }


### PR DESCRIPTION
Fixes the alignment problem where the Run Flow button dances around when hovered on menu icon.

A video of the bug is [here](https://photos.app.goo.gl/whmS6RRJLhvqHlUu1)
