### PR TITLE
[609] - Device profile - fixed the problem with importing application 

### DIFF
--- a/src/server/modules/apps/import.v2.js
+++ b/src/server/modules/apps/import.v2.js
@@ -27,20 +27,19 @@ export function importApp(fromApp) {
         throw ErrorManager.createValidationError('Validation error', { details: errors });
       }
     })
-    .then(() => AppsManager.create(clonedApp))
-    .then(app => {
+    .then(() => {
       if (appProfile === FLOGO_PROFILE_TYPES.DEVICE) {
         return Promise.all([
-          ContribDeviceManager.find({ type: 'flogo:device:trigger' }),
-          ContribDeviceManager.find({ type: 'flogo:device:activity' }),
+          ContribDeviceManager.find({type: 'flogo:device:trigger'}),
+          ContribDeviceManager.find({type: 'flogo:device:activity'}),
         ])
-        .then(([triggerContribs, activityContribs]) => {
-          fromApp.triggers = fromApp.triggers.map(trigger => deviceTriggerFormatter(trigger, triggerContribs));
-          fromApp.actions = fromApp.actions.map(action => deviceActionFormatter(action, activityContribs));
-        });
+          .then(([triggerContribs, activityContribs]) => {
+            fromApp.triggers = fromApp.triggers.map(trigger => deviceTriggerFormatter(trigger, triggerContribs));
+            fromApp.actions = fromApp.actions.map(action => deviceActionFormatter(action, activityContribs));
+          });
       }
-      return app;
     })
+    .then(() => AppsManager.create(clonedApp))
     .then(app => Promise.all(fromApp.actions.map(action =>
         ActionsManager.create(app.id, action).then(storedAction => [action.id, storedAction])))
         .then(actionPairs => ({ appId: app.id, actionsMap: new Map(actionPairs) })),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
I am unable to import an application of device profile type

**Fix details:**
There is a logical problem which is returning an inappropriate application JSON details to subsequent **then** for a device type profile application import.

Earlier an application's JSON trigger and actions are formatted for device profiles before importing. Recently while allowing changes to support creating multiple actions for a same trigger, the logic has been placed incorrectly which will not return the proper data to the successor **then** functions which causes an internal error in server side.

Now we are formatting the given application JSON before creating an application in database.

**Things to Test**

- [ ] Create a device profile, export it and try to import it back
- [ ] Create a device profile, add a flow with a trigger and tasks in it, export it and try to import it back
- [ ] Create a microservice profile, export it and try to import it back
- [ ] Create a microservice profile, add a flow with a trigger and tasks in it, export it and try to import it back