### PR TITLE
[605] - Running a flow will no longer update the previous state of the flow schema

### DIFF
--- a/src/client/flogo/flow/flow.component.ts
+++ b/src/client/flogo/flow/flow.component.ts
@@ -1754,8 +1754,13 @@ export class FlowComponent implements OnInit, OnDestroy {
   }
 
   onRunFlow(modifiedInputs: FlowMetadataAttribute[]) {
-    this.flow.metadata.input = modifiedInputs;
-    const flowUpdatePromise = modifiedInputs.length ? this._updateFlow(this.flow) : Promise.resolve(this.flow);
+    let flowUpdatePromise;
+    if (modifiedInputs.length) {
+      this.flow.metadata.input = modifiedInputs;
+      flowUpdatePromise = this._updateFlow(this.flow);
+    } else {
+      flowUpdatePromise = Promise.resolve(this.flow);
+    }
     flowUpdatePromise.then(() => this._runFromRoot())
       .then(() => {
         const parsedURL = location.pathname.split('task/');

--- a/src/client/flogo/flow/run-flow/run-flow.component.ts
+++ b/src/client/flogo/flow/run-flow/run-flow.component.ts
@@ -26,12 +26,21 @@ export class FlogoRunFlowComponent {
     this.runFlowFormGroup = formGroup;
   }
 
+  private resetRunFlowFormGroup() {
+    this.runFlowFormGroup = undefined;
+  }
+
   /*
   * Run Flow form is not shown when the flow does not have any input metadata for the flow.
   * The Run Flow button should directly run the flow
   */
   handleRunFlowClick() {
-    this.flowInputs.length > 0 ? this.showHideRun() : this.onRunFlowSubmit();
+    if (this.flowInputs.length > 0) {
+      this.showHideRun();
+    } else {
+      this.resetRunFlowFormGroup();
+      this.onRunFlowSubmit();
+    }
   }
 
   showHideRun() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Removing all the inputs from flow schema and running a flow adds them back


**What is the new behavior?**
Once the inputs are removed from flow schema they should be maintained as removed

**Cases to test**

- [ ] Adding an input for a flow and running the flow should not remove the input
- [ ] Removing an input for a flow and running the flow should remove the input
- [ ] Modifying the name of an input for a flow and running the flow should ask for the input's data to run the flow