### PR TITLE
Fix flow designer svgs for safari.

### DIFF
--- a/src/client/flogo/flow/shared/diagram/models/diagram.model.ts
+++ b/src/client/flogo/flow/shared/diagram/models/diagram.model.ts
@@ -1095,6 +1095,7 @@ export class FlogoFlowDiagram implements IFlogoFlowDiagram {
   }
 
   private makeTile() {
+    const urlLocation = window.location.href;
     /* tslint:disable:max-line-length */
     return `
     <svg class="${CLS.diagramNodeDetailShape}" 
@@ -1124,14 +1125,14 @@ export class FlogoFlowDiagram implements IFlogoFlowDiagram {
         </defs>
         <g class="tile" fill="none" fill-rule="evenodd" transform="translate(11 9)">
             <g class="tile__default">
-                <use class="tile__shadow" fill="#000" filter="url(#flogo-diagram-tile-shadow)" xlink:href="#flogo-diagram-tile-shape"/>
-                <use class="tile__bg" fill="url(#flogo-diagram-tile-bg-default)" xlink:href="#flogo-diagram-tile-shape"/>
+                <use class="tile__shadow" fill="#000" filter="url(${urlLocation}#flogo-diagram-tile-shadow)" xlink:href="${urlLocation}#flogo-diagram-tile-shape"/>
+                <use class="tile__bg" fill="url(${urlLocation}#flogo-diagram-tile-bg-default)" xlink:href="${urlLocation}#flogo-diagram-tile-shape"/>
                 <path class="tile__stroke" stroke="#F4F4F4" stroke-width=".8" d="M123.005 55.147l-13.26-29.446-.035-.165V8a7.6 7.6 0 0 0-7.6-7.6h-94A7.6 7.6 0 0 0 .51 8v94a7.6 7.6 0 0 0 7.6 7.6h94a7.6 7.6 0 0 0 7.6-7.6V84.758l.035-.164 13.26-29.447z"/>
             </g>
     
             <g class="tile__terminal">
-                <use class="tile__shadow" fill="#000" filter="url(#flogo-diagram-tile-shadow)" xlink:href="#flogo-diagram-tile-shape-terminal"/>
-                <use class="tile__bg" fill="url(#flogo-diagram-tile-bg-default)" xlink:href="#flogo-diagram-tile-shape-terminal" />
+                <use class="tile__shadow" fill="#000" filter="url(${urlLocation}#flogo-diagram-tile-shadow)" xlink:href="${urlLocation}#flogo-diagram-tile-shape-terminal"/>
+                <use class="tile__bg" fill="url(${urlLocation}#flogo-diagram-tile-bg-default)" xlink:href="${urlLocation}#flogo-diagram-tile-shape-terminal" />
                 <rect class="tile__stroke" width="109.2" height="109.2" x=".51" y=".4" stroke="#F4F4F4" stroke-width=".8" rx="8"/>
             </g>
         </g>
@@ -1141,6 +1142,7 @@ export class FlogoFlowDiagram implements IFlogoFlowDiagram {
   }
 
   private makeErrorRootTile() {
+    const urlLocation = window.location.href;
     return `<svg class="${CLS.diagramNodeDetailShape}" xmlns="http://www.w3.org/2000/svg" 
         xmlns:xlink="http://www.w3.org/1999/xlink" width="52" height="52" viewBox="0 0 52 52">
         <defs>
@@ -1153,8 +1155,9 @@ export class FlogoFlowDiagram implements IFlogoFlowDiagram {
             </filter>
         </defs>
         <g fill="none" fill-rule="evenodd" transform="translate(2 1)">
-            <use fill="#000" filter="url(#flogo-diagram-error-bg)" xlink:href="#flogo-diagram-error-shape"/>
-            <use fill="#FBCDD1" xlink:href="#flogo-diagram-error-shape"/>
+            <use fill="#000" filter="url(${urlLocation}#flogo-diagram-error-bg)"
+              xlink:href="${urlLocation}#flogo-diagram-error-shape"/>
+            <use fill="#FBCDD1" xlink:href="${urlLocation}#flogo-diagram-error-shape"/>
             <path stroke="#EE3342" stroke-width=".8" d="M39.672.4H2.4a2 2 0 0 0-2 2v43.2a2 2 0 0 0 2 2h37.272L47.578 24 39.672.4z"/>
         </g>
     </svg>


### PR DESCRIPTION
SVGs in the flow diagram were not being displayed in Safari because Safari can't deal with a relative reference like `#mySvg` and it needs to have the full path `http://url/thispage#mySvg`.

Before fix:
<img width="802" alt="screen shot 2018-01-09 at 9 43 39 pm" src="https://user-images.githubusercontent.com/17577698/34793365-fe0c418e-f5ff-11e7-8cab-88238b38e4bf.png">

