### PR TITLE
Remove use of task.title.

### DIFF
--- a/src/client/flogo/flow/core/flow-for-canvas.mock.ts
+++ b/src/client/flogo/flow/core/flow-for-canvas.mock.ts
@@ -76,7 +76,6 @@ export let resultantFlowModelForCanvas = {
     'items': {
       'some_id_7': {
         'name': 'First Log',
-        'title': 'Log Message',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
         'description': 'Simple Log Activity',
@@ -122,7 +121,6 @@ export let resultantFlowModelForCanvas = {
       },
       'some_id_8': {
         'name': 'Counter1',
-        'title': 'Increment Counter',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/counter',
         'description': 'Simple Global Counter Activity',
@@ -168,7 +166,6 @@ export let resultantFlowModelForCanvas = {
       },
       'some_id_9': {
         'name': 'Second Log',
-        'title': 'Log Message',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
         'description': 'Simple Log Activity',
@@ -214,7 +211,6 @@ export let resultantFlowModelForCanvas = {
       },
       'some_id_10': {
         'name': 'Third Log',
-        'title': 'Log Message',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
         'description': 'Simple Log Activity',
@@ -342,7 +338,6 @@ export let resultantFlowModelForCanvas = {
     'tasks': {
       'some_id_7': {
         'name': 'First Log',
-        'title': 'Log Message',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
         'description': 'Simple Log Activity',
@@ -388,7 +383,6 @@ export let resultantFlowModelForCanvas = {
       },
       'some_id_8': {
         'name': 'Counter1',
-        'title': 'Increment Counter',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/counter',
         'description': 'Simple Global Counter Activity',
@@ -434,7 +428,6 @@ export let resultantFlowModelForCanvas = {
       },
       'some_id_9': {
         'name': 'Second Log',
-        'title': 'Log Message',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
         'description': 'Simple Log Activity',
@@ -480,7 +473,6 @@ export let resultantFlowModelForCanvas = {
       },
       'some_id_10': {
         'name': 'Third Log',
-        'title': 'Log Message',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
         'description': 'Simple Log Activity',

--- a/src/client/flogo/flow/core/models/ui-converter.model.ts
+++ b/src/client/flogo/flow/core/models/ui-converter.model.ts
@@ -377,7 +377,6 @@ class ItemFactory {
   static getSharedProperties(installed) {
     const defaults = {
       name: '',
-      title: '',
       version: '',
       homepage: '',
       description: '',
@@ -391,7 +390,7 @@ class ItemFactory {
       },
       __status: {}
     };
-    return Object.assign({}, defaults, _.pick(installed, ['name', 'title', 'version', 'homepage', 'description', 'ref']));
+    return Object.assign({}, defaults, _.pick(installed, ['name', 'version', 'homepage', 'description', 'ref']));
   }
 
   static makeTriggerError(trigger) {
@@ -401,7 +400,6 @@ class ItemFactory {
       version: '',
       name: 'On Error',
       description: '',
-      title: 'On Error',
       activityType: '',
       triggerType: '__error-trigger',
       attributes: {

--- a/src/client/flogo/flow/core/ui-model-flow.mock.ts
+++ b/src/client/flogo/flow/core/ui-model-flow.mock.ts
@@ -262,7 +262,6 @@ export let mockActivitiesDetails = [
     'id': 'tibco-log',
     'name': 'tibco-log',
     'version': '0.0.1',
-    'title': 'Log Message',
     'description': 'Simple Log Activity',
     'ref': 'github.com/TIBCOSoftware/flogo-contrib/activity/log',
     'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
@@ -294,7 +293,6 @@ export let mockActivitiesDetails = [
     'id': 'tibco-counter',
     'name': 'tibco-counter',
     'version': '0.0.1',
-    'title': 'Increment Counter',
     'description': 'Simple Global Counter Activity',
     'ref': 'github.com/TIBCOSoftware/flogo-contrib/activity/counter',
     'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/counter',
@@ -398,7 +396,6 @@ export let mockResultantUIFlow = {
   'items': {
     'some_id_7': {
       'name': 'First Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',
@@ -444,7 +441,6 @@ export let mockResultantUIFlow = {
     },
     'some_id_8': {
       'name': 'Counter1',
-      'title': 'Increment Counter',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/counter',
       'description': 'Simple Global Counter Activity',
@@ -490,7 +486,6 @@ export let mockResultantUIFlow = {
     },
     'some_id_9': {
       'name': 'Second Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',
@@ -536,7 +531,6 @@ export let mockResultantUIFlow = {
     },
     'some_id_10': {
       'name': 'Third Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',
@@ -673,7 +667,6 @@ export let mockResultantUIFlowWithError = {
   'items': {
     'some_id_7': {
       'name': 'First Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',
@@ -719,7 +712,6 @@ export let mockResultantUIFlowWithError = {
     },
     'some_id_8': {
       'name': 'Counter1',
-      'title': 'Increment Counter',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/counter',
       'description': 'Simple Global Counter Activity',
@@ -765,7 +757,6 @@ export let mockResultantUIFlowWithError = {
     },
     'some_id_9': {
       'name': 'Second Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',
@@ -811,7 +802,6 @@ export let mockResultantUIFlowWithError = {
     },
     'some_id_10': {
       'name': 'Third Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',
@@ -915,7 +905,6 @@ export let mockResultantUIFlowWithError = {
         'version': '',
         'name': 'On Error',
         'description': '',
-        'title': 'On Error',
         'activityType': '',
         'triggerType': '__error-trigger',
         'attributes': {
@@ -967,7 +956,6 @@ export let mockResultantUIFlowWithError = {
       },
       'some_id_4': {
         'name': 'Error Log',
-        'title': 'Log Message',
         'version': '0.0.1',
         'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
         'description': 'Simple Log Activity',
@@ -1091,7 +1079,6 @@ export let mockResultantUIFlowWithTransformations = {
   'items': {
     'some_id_7': {
       'name': 'First Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',
@@ -1143,7 +1130,6 @@ export let mockResultantUIFlowWithTransformations = {
     },
     'some_id_8': {
       'name': 'Counter1',
-      'title': 'Increment Counter',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/counter',
       'description': 'Simple Global Counter Activity',
@@ -1189,7 +1175,6 @@ export let mockResultantUIFlowWithTransformations = {
     },
     'some_id_9': {
       'name': 'Second Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',
@@ -1235,7 +1220,6 @@ export let mockResultantUIFlowWithTransformations = {
     },
     'some_id_10': {
       'name': 'Third Log',
-      'title': 'Log Message',
       'version': '0.0.1',
       'homepage': 'https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/log',
       'description': 'Simple Log Activity',

--- a/src/client/flogo/flow/flow.component.ts
+++ b/src/client/flogo/flow/flow.component.ts
@@ -1622,7 +1622,7 @@ export class FlowComponent implements OnInit, OnDestroy {
     if (outputMapper) {
       overridePropsToMap = metadata.output;
       overrideMappings = _.get(selectedTile.attributes.inputs, '[0].value', []);
-      transformTitle = this.translate.instant('TASK-CONFIGURATOR:TITLE-OUTPUT-MAPPER', { taskName: selectedTile.title });
+      transformTitle = this.translate.instant('TASK-CONFIGURATOR:TITLE-OUTPUT-MAPPER', { taskName: selectedTile.name });
       searchTitleKey = 'TASK-CONFIGURATOR:FLOW-OUTPUTS';
       inputMappingsTabLabelKey = 'TASK-CONFIGURATOR:FLOW-OUTPUTS';
     }

--- a/src/client/flogo/flow/shared/diagram/models/task.model.ts
+++ b/src/client/flogo/flow/shared/diagram/models/task.model.ts
@@ -11,7 +11,6 @@ export interface IFlogoFlowDiagramTask {
   name ?: string;
   ref ?: string;
   description ?: string;
-  title ?: string;
   activityType?: string;
   triggerType?: string;
   attributes ?: IFlogoFlowDiagramTaskAttributes;
@@ -39,7 +38,6 @@ export class FlogoFlowDiagramTask implements IFlogoFlowDiagramTask {
   version: string;
   name: string;
   description: string;
-  title: string;
   activityType: string;
   ref: string;
   triggerType: string;
@@ -74,7 +72,6 @@ export class FlogoFlowDiagramTask implements IFlogoFlowDiagramTask {
     this.version = task.version || this.version || '';
     this.name = task.name || this.name || 'new task';
     this.description = task.description || this.description || '';
-    this.title = task.title || this.title || '';
     this.activityType = task.activityType || this.activityType || '';
     this.ref = task.ref || this.ref || '';
 
@@ -131,7 +128,7 @@ export function makeDefaultErrorTrigger(id): IFlogoFlowDiagramTask {
   const errorTrigger = new FlogoFlowDiagramTask({
     id: id,
     name: 'On Error',
-    title: 'On Error',
+    // title: 'On Error',
     type: FLOGO_TASK_TYPE.TASK_ROOT,
     triggerType: FLOGO_ERROR_ROOT_NAME,
     attributes: {

--- a/src/client/flogo/flow/shared/mapper/utils/mapper-translator.ts
+++ b/src/client/flogo/flow/shared/mapper/utils/mapper-translator.ts
@@ -43,7 +43,7 @@ export class MapperTranslator {
           const taskId = flogoIDDecode(tile.id);
           const tileSchema = MapperTranslator.attributesToObjectDescriptor(outputs || []);
           tileSchema.rootType = this.getRootType(tile);
-          tileSchema.title = tile.title;
+          tileSchema.title = tile.name;
           rootSchema.properties[taskId] = tileSchema;
         }
       } else {

--- a/src/client/flogo/flow/task-configurator/task-configurator.component.spec.ts
+++ b/src/client/flogo/flow/task-configurator/task-configurator.component.spec.ts
@@ -82,7 +82,6 @@ describe('Component: TaskConfiguratorComponent', () => {
           'type': 0,
           'triggerType': 'tibco-timer',
           'name': 'Timer Trigger',
-          'title': 'Timer Trigger',
           'settings': [],
           'outputs': [
             {
@@ -165,7 +164,7 @@ describe('Component: TaskConfiguratorComponent', () => {
         'activityType': 'tibco-log',
         'name': 'Logger',
         'version': '0.0.1',
-        'title': 'Log Activity',
+        // 'title': 'Log Activity',
         'description': 'To log the number',
         'attributes': {
           'inputs': [

--- a/src/client/flogo/flow/task-configurator/task-configurator.component.ts
+++ b/src/client/flogo/flow/task-configurator/task-configurator.component.ts
@@ -189,7 +189,7 @@ export class TaskConfiguratorComponent implements OnDestroy {
     this.inputScope = eventData.scope;
 
     if (!this.title && this.currentTile) {
-      this.title = this.currentTile.title;
+      this.title = this.currentTile.name;
     }
     this.inputsSearchPlaceholderKey = eventData.inputsSearchPlaceholderKey || 'TASK-CONFIGURATOR:ACTIVITY-INPUTS';
 

--- a/src/client/flogo/shared/utils.ts
+++ b/src/client/flogo/shared/utils.ts
@@ -131,7 +131,6 @@ export function activitySchemaToTask(schema: any): any {
     ref: schema.ref,
     name: _.get(schema, 'title', _.get(schema, 'name', 'Activity')),
     version: _.get(schema, 'version', ''),
-    title: _.get(schema, 'title', ''),
     description: _.get(schema, 'description', ''),
     homepage: _.get(schema, 'homepage', ''),
     attributes: {
@@ -168,7 +167,6 @@ export function activitySchemaToTrigger(schema: any): any {
     ref: schema.ref,
     name: _.get(schema, 'title', _.get(schema, 'name', 'Activity')),
     version: _.get(schema, 'version', ''),
-    title: _.get(schema, 'title', ''),
     description: _.get(schema, 'description', ''),
     homepage: _.get(schema, 'homepage', ''),
     settings: _.get(schema, 'settings', ''),


### PR DESCRIPTION
Removed use of old 'title' property in task/tiles that was replaced by 'name' long back ago.

Title/name were used inconsistently and this also fixes a bug that happened when you changed a tile name from the UI and the change was not reflected in the mapper.
