### PR TITLE
Remove client enum for data types, use string labels directly.

### DIFF
--- a/src/client/flogo/core/constants.spec.ts
+++ b/src/client/flogo/core/constants.spec.ts
@@ -1,0 +1,11 @@
+import { ValueTypes } from './constants';
+
+describe('ValueType constants', function() {
+  const allTypes = [...ValueTypes.allTypes];
+  allTypes.forEach(type => {
+    it(`Should define a default value for ${type}`, () => {
+      expect(ValueTypes.defaultValueForType.has(type))
+        .toBeTruthy(`Default value for ${type} is not defined`);
+    });
+  });
+});

--- a/src/client/flogo/core/constants.ts
+++ b/src/client/flogo/core/constants.ts
@@ -17,17 +17,38 @@ export enum FLOGO_TASK_TYPE {
 
 export enum FLOGO_PROCESS_TYPE { DEFAULT = 1 }
 
-export enum FLOGO_TASK_ATTRIBUTE_TYPE {
-  STRING,
-  INTEGER,
-  NUMBER,
-  BOOLEAN,
-  OBJECT,
-  ARRAY,
-  PARAMS,
-  ANY,
-  INT,
-  COMPLEX_OBJECT
+// can be simplified using string enums in typescript >= 2.1
+export namespace ValueTypes {
+  export type ValueType = 'string' | 'integer' | 'int' | 'number' | 'boolean' | 'object' | 'array' | 'params' | 'any' |  'complex_object';
+
+  export const STRING: 'string' = 'string';
+  export const INTEGER: 'integer' = 'integer';
+  // todo: should be removed? only used by device activities
+  export const INT: 'int' = 'int';
+  export const NUMBER: 'number' = 'number';
+  export const BOOLEAN: 'boolean' = 'boolean';
+  export const OBJECT: 'object' = 'object';
+  export const ARRAY: 'array' = 'array';
+  export const ANY: 'any' = 'any';
+  export const PARAMS: 'params' = 'params';
+  export const COMPLEX_OBJECT: 'complex_object' = 'complex_object';
+
+  export const allTypes: ReadonlyArray<ValueType> = [ STRING, INTEGER, NUMBER, BOOLEAN, OBJECT, ARRAY, ANY, PARAMS, COMPLEX_OBJECT ];
+
+  // can be type safe in typescript >= 2.1 using "keyof" keyword
+  export const defaultValueForType = new Map<ValueType, any>([
+    [STRING, ''],
+    [INTEGER, 0],
+    [INT, 0],
+    [NUMBER, 0.0],
+    [BOOLEAN, false],
+    [OBJECT, null],
+    [ARRAY, []],
+    [PARAMS, null],
+    [ANY, null],
+    [COMPLEX_OBJECT, null],
+  ]);
+
 }
 
 /**
@@ -38,21 +59,6 @@ export const FLOGO_PROCESS_MODELS = {
   'DEFAULT': 'simple'
 };
 
-/* construct the default values fo types */
-
-const defaultValues = <{ [key: number]: any }>{};
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.STRING] = '';
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.INTEGER] = 0;
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.INT] = 0;
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.NUMBER] = 0.0;
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.BOOLEAN] = false;
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.OBJECT] = null;
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.ARRAY] = [];
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.PARAMS] = null;
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.ANY] = null;
-defaultValues[FLOGO_TASK_ATTRIBUTE_TYPE.COMPLEX_OBJECT] = null;
-
-export const DEFAULT_VALUES_OF_TYPES = defaultValues;
 /**
  * Defined in modules
  */

--- a/src/client/flogo/core/index.ts
+++ b/src/client/flogo/core/index.ts
@@ -1,4 +1,5 @@
-export { CoreModule } from './core.module';
+export * from './interfaces';
+export * from './constants';
 export { initializer } from './initializer';
 export { LanguageService } from './language';
-export * from './interfaces';
+export { CoreModule } from './core.module';

--- a/src/client/flogo/core/interfaces/common/action.ts
+++ b/src/client/flogo/core/interfaces/common/action.ts
@@ -8,6 +8,6 @@ export interface Action {
   createdAt: string;
   updatedAt: string;
   data: {
-    flow: flow.Flow
+    flow?: flow.Flow
   };
 }

--- a/src/client/flogo/core/interfaces/flow/attribute-mapping.ts
+++ b/src/client/flogo/core/interfaces/flow/attribute-mapping.ts
@@ -1,7 +1,5 @@
-import { FLOGO_TASK_ATTRIBUTE_TYPE } from 'flogo/core/constants';
-
 export interface AttributeMapping {
-  type: FLOGO_TASK_ATTRIBUTE_TYPE;
+  type: number;
   value: any;
   mapTo: string;
 }

--- a/src/client/flogo/core/interfaces/flow/attribute.ts
+++ b/src/client/flogo/core/interfaces/flow/attribute.ts
@@ -1,8 +1,8 @@
-import { FLOGO_TASK_ATTRIBUTE_TYPE } from '@flogo/core/constants';
+import { ValueTypes } from '../../constants';
 
 export interface TaskAttribute {
   name: string;
-  type: FLOGO_TASK_ATTRIBUTE_TYPE;
+  type: ValueTypes.ValueType;
   value: any;
   title ?: string;
   description ?: string;

--- a/src/client/flogo/core/interfaces/flow/flow-metadata-attribute.ts
+++ b/src/client/flogo/core/interfaces/flow/flow-metadata-attribute.ts
@@ -1,5 +1,7 @@
+import { ValueTypes } from '../../constants';
+
 export interface MetadataAttribute {
   name: string;
-  type: string;
+  type: ValueTypes.ValueType;
   value?: any;
 }

--- a/src/client/flogo/flow/core/flow-for-canvas.mock.ts
+++ b/src/client/flogo/flow/core/flow-for-canvas.mock.ts
@@ -90,19 +90,19 @@ export let resultantFlowModelForCanvas = {
           'inputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': 'string',
               'value': 'I am here 1',
               'required': false
             },
             {
               'name': 'flowInfo',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'addToFlow',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             }
@@ -110,7 +110,7 @@ export let resultantFlowModelForCanvas = {
           'outputs': [
             {
               'name': 'message',
-              'type': 0
+              'type': 'string'
             }
           ]
         },
@@ -135,19 +135,19 @@ export let resultantFlowModelForCanvas = {
           'inputs': [
             {
               'name': 'counterName',
-              'type': 0,
+              'type': 'string',
               'value': 'counter1',
               'required': false
             },
             {
               'name': 'increment',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'reset',
-              'type': 3,
+              'type': 'boolean',
               'value': false,
               'required': false
             }
@@ -155,7 +155,7 @@ export let resultantFlowModelForCanvas = {
           'outputs': [
             {
               'name': 'value',
-              'type': 1
+              'type': 'integer'
             }
           ]
         },
@@ -180,19 +180,19 @@ export let resultantFlowModelForCanvas = {
           'inputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': 'string',
               'value': 'I am here 2',
               'required': false
             },
             {
               'name': 'flowInfo',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'addToFlow',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             }
@@ -200,7 +200,7 @@ export let resultantFlowModelForCanvas = {
           'outputs': [
             {
               'name': 'message',
-              'type': 0
+              'type': 'string'
             }
           ]
         },
@@ -225,19 +225,19 @@ export let resultantFlowModelForCanvas = {
           'inputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': 'string',
               'value': 'I am here 3',
               'required': false
             },
             {
               'name': 'flowInfo',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'addToFlow',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             }
@@ -245,7 +245,7 @@ export let resultantFlowModelForCanvas = {
           'outputs': [
             {
               'name': 'message',
-              'type': 0
+              'type': 'string'
             }
           ]
         },
@@ -352,19 +352,19 @@ export let resultantFlowModelForCanvas = {
           'inputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': 'string',
               'value': 'I am here 1',
               'required': false
             },
             {
               'name': 'flowInfo',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'addToFlow',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             }
@@ -372,7 +372,7 @@ export let resultantFlowModelForCanvas = {
           'outputs': [
             {
               'name': 'message',
-              'type': 0
+              'type': 'string'
             }
           ]
         },
@@ -397,19 +397,19 @@ export let resultantFlowModelForCanvas = {
           'inputs': [
             {
               'name': 'counterName',
-              'type': 0,
+              'type': 'string',
               'value': 'counter1',
               'required': false
             },
             {
               'name': 'increment',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'reset',
-              'type': 3,
+              'type': 'boolean',
               'value': false,
               'required': false
             }
@@ -417,7 +417,7 @@ export let resultantFlowModelForCanvas = {
           'outputs': [
             {
               'name': 'value',
-              'type': 1
+              'type': 'integer'
             }
           ]
         },
@@ -442,19 +442,19 @@ export let resultantFlowModelForCanvas = {
           'inputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': 'string',
               'value': 'I am here 2',
               'required': false
             },
             {
               'name': 'flowInfo',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'addToFlow',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             }
@@ -462,7 +462,7 @@ export let resultantFlowModelForCanvas = {
           'outputs': [
             {
               'name': 'message',
-              'type': 0
+              'type': 'string'
             }
           ]
         },
@@ -487,19 +487,19 @@ export let resultantFlowModelForCanvas = {
           'inputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': 'string',
               'value': 'I am here 3',
               'required': false
             },
             {
               'name': 'flowInfo',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'addToFlow',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             }
@@ -507,7 +507,7 @@ export let resultantFlowModelForCanvas = {
           'outputs': [
             {
               'name': 'message',
-              'type': 0
+              'type': 'string'
             }
           ]
         },

--- a/src/client/flogo/flow/core/models/profiles/microservice-converter.model.ts
+++ b/src/client/flogo/flow/core/models/profiles/microservice-converter.model.ts
@@ -1,10 +1,9 @@
+import { FlowMetadata, MetadataAttribute } from '@flogo/core/interfaces';
+import { ValueTypes } from '@flogo/core/constants';
+import { RESTAPIActivitiesService } from '@flogo/core/services/restapi/activities-api.service';
+import { RESTAPITriggersService } from '@flogo/core/services/restapi/triggers-api.service';
+import { ErrorService } from '@flogo/core/services/error.service';
 import { AbstractModelConverter } from '../ui-converter.model';
-import { RESTAPIActivitiesService } from '../../../../core/services/restapi/activities-api.service';
-import { RESTAPITriggersService } from '../../../../core/services/restapi/triggers-api.service';
-import { ErrorService } from '../../../../core/services/error.service';
-import { FLOGO_TASK_ATTRIBUTE_TYPE } from '../../../../core/constants';
-import { FlowMetadata } from '@flogo/core';
-import { MetadataAttribute } from '../../../../core/interfaces/flow/flow-metadata-attribute';
 
 export class MicroServiceModelConverter extends AbstractModelConverter {
   triggerService: RESTAPITriggersService;
@@ -52,7 +51,7 @@ export class MicroServiceModelConverter extends AbstractModelConverter {
     metadata.input = flowInputs.map(input => {
       const inputMetadata: MetadataAttribute = {
         name: input.name,
-        type: FLOGO_TASK_ATTRIBUTE_TYPE[_.get(input, 'type', 'STRING').toUpperCase()],
+        type: input.type || ValueTypes.STRING,
       };
       if (!_.isUndefined(input.value)) {
         inputMetadata.value = input.value;
@@ -60,7 +59,7 @@ export class MicroServiceModelConverter extends AbstractModelConverter {
       return inputMetadata;
     });
     metadata.output = flowOutputs.map(input => ({
-      name: input.name, type: FLOGO_TASK_ATTRIBUTE_TYPE[_.get(input, 'type', 'STRING').toUpperCase()],
+      name: input.name, type: input.type || ValueTypes.STRING,
     }));
 
     return {

--- a/src/client/flogo/flow/core/models/ui-converter.model.ts
+++ b/src/client/flogo/flow/core/models/ui-converter.model.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { FLOGO_TASK_ATTRIBUTE_TYPE, FLOGO_TASK_TYPE } from '@flogo/core/constants';
+import { FLOGO_TASK_TYPE, ValueTypes } from '@flogo/core/constants';
 import {flogoGenTriggerID, flogoIDEncode, isSubflowTask} from '@flogo/shared/utils';
 import { ErrorService } from '@flogo/core/services/error.service';
 
@@ -409,21 +409,21 @@ class ItemFactory {
       triggerType: '__error-trigger',
       attributes: {
         outputs: [{
-          name: 'activity', type: FLOGO_TASK_ATTRIBUTE_TYPE.STRING, title: 'activity', value: '',
+          name: 'activity', type: ValueTypes.STRING, title: 'activity', value: '',
         }, {
-          name: 'message', type: FLOGO_TASK_ATTRIBUTE_TYPE.STRING, title: 'message', value: '',
+          name: 'message', type: ValueTypes.STRING, title: 'message', value: '',
         }, {
-          name: 'data', type: FLOGO_TASK_ATTRIBUTE_TYPE.ANY, title: 'data', value: '',
+          name: 'data', type: ValueTypes.ANY, title: 'data', value: '',
         }],
       },
       inputMappings: [],
       outputMappings: [],
       outputs: [{
-        name: 'activity', type: FLOGO_TASK_ATTRIBUTE_TYPE.STRING, title: 'activity', value: '',
+        name: 'activity', type: ValueTypes.STRING, title: 'activity', value: '',
       }, {
-        name: 'message', type: FLOGO_TASK_ATTRIBUTE_TYPE.STRING, title: 'message', value: '',
+        name: 'message', type: ValueTypes.STRING, title: 'message', value: '',
       }, {
-        name: 'data', type: FLOGO_TASK_ATTRIBUTE_TYPE.ANY, title: 'data', value: '',
+        name: 'data', type: ValueTypes.ANY, title: 'data', value: '',
       }],
       __props: {
         errors: [],
@@ -478,7 +478,8 @@ class ItemFactory {
     });
 
     const mapType = prop => ({
-      name: prop.name, type: FLOGO_TASK_ATTRIBUTE_TYPE[_.get(prop, 'type', 'STRING').toUpperCase()],
+      name: prop.name,
+      type: prop.type || ValueTypes.STRING,
     });
     // -----------------
     // set outputs
@@ -523,7 +524,7 @@ class ItemFactory {
 
       const newAttribute: any = {
         name: schemaInput.name,
-        type: FLOGO_TASK_ATTRIBUTE_TYPE[_.get(schemaInput, 'type', 'STRING').toUpperCase()],
+        type: schemaInput.type || ValueTypes.STRING,
       };
 
       if (attrValue) {
@@ -542,7 +543,8 @@ class ItemFactory {
     const outputs = activitySchema.outputs || [];
 
     item.attributes.outputs = outputs.map(output => ({
-      name: output.name, type: FLOGO_TASK_ATTRIBUTE_TYPE[_.get(output, 'type', 'STRING').toUpperCase()],
+      name: output.name,
+      type: output.type || ValueTypes.STRING,
     }));
 
 

--- a/src/client/flogo/flow/core/ui-model-flow.mock.ts
+++ b/src/client/flogo/flow/core/ui-model-flow.mock.ts
@@ -410,19 +410,19 @@ export let mockResultantUIFlow = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': 'I am here 1',
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -430,7 +430,7 @@ export let mockResultantUIFlow = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },
@@ -455,19 +455,19 @@ export let mockResultantUIFlow = {
         'inputs': [
           {
             'name': 'counterName',
-            'type': 0,
+            'type': 'string',
             'value': 'counter1',
             'required': false
           },
           {
             'name': 'increment',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'reset',
-            'type': 3,
+            'type': 'boolean',
             'value': false,
             'required': false
           }
@@ -475,7 +475,7 @@ export let mockResultantUIFlow = {
         'outputs': [
           {
             'name': 'value',
-            'type': 1
+            'type': 'integer'
           }
         ]
       },
@@ -500,19 +500,19 @@ export let mockResultantUIFlow = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': 'I am here 2',
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -520,7 +520,7 @@ export let mockResultantUIFlow = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },
@@ -545,19 +545,19 @@ export let mockResultantUIFlow = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': 'I am here 3',
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -565,7 +565,7 @@ export let mockResultantUIFlow = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },
@@ -681,19 +681,19 @@ export let mockResultantUIFlowWithError = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': 'I am here 1',
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -701,7 +701,7 @@ export let mockResultantUIFlowWithError = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },
@@ -726,19 +726,19 @@ export let mockResultantUIFlowWithError = {
         'inputs': [
           {
             'name': 'counterName',
-            'type': 0,
+            'type': 'string',
             'value': 'counter1',
             'required': false
           },
           {
             'name': 'increment',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'reset',
-            'type': 3,
+            'type': 'boolean',
             'value': false,
             'required': false
           }
@@ -746,7 +746,7 @@ export let mockResultantUIFlowWithError = {
         'outputs': [
           {
             'name': 'value',
-            'type': 1
+            'type': 'integer'
           }
         ]
       },
@@ -771,19 +771,19 @@ export let mockResultantUIFlowWithError = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': 'I am here 2',
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -791,7 +791,7 @@ export let mockResultantUIFlowWithError = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },
@@ -816,19 +816,19 @@ export let mockResultantUIFlowWithError = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': 'I am here 3',
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -836,7 +836,7 @@ export let mockResultantUIFlowWithError = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },
@@ -911,19 +911,19 @@ export let mockResultantUIFlowWithError = {
           'outputs': [
             {
               'name': 'activity',
-              'type': 0,
+              'type': 'string',
               'title': 'activity',
               'value': ''
             },
             {
               'name': 'message',
-              'type': 0,
+              'type': 'string',
               'title': 'message',
               'value': ''
             },
             {
               'name': 'data',
-              'type': 7,
+              'type': 'any',
               'title': 'data',
               'value': ''
             }
@@ -934,19 +934,19 @@ export let mockResultantUIFlowWithError = {
         'outputs': [
           {
             'name': 'activity',
-            'type': 0,
+            'type': 'string',
             'title': 'activity',
             'value': ''
           },
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'title': 'message',
             'value': ''
           },
           {
             'name': 'data',
-            'type': 7,
+            'type': 'any',
             'title': 'data',
             'value': ''
           }
@@ -970,19 +970,19 @@ export let mockResultantUIFlowWithError = {
           'inputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': 'string',
               'value': 'Error Log 1',
               'required': false
             },
             {
               'name': 'flowInfo',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             },
             {
               'name': 'addToFlow',
-              'type': 3,
+              'type': 'boolean',
               'value': 'true',
               'required': false
             }
@@ -990,7 +990,7 @@ export let mockResultantUIFlowWithError = {
           'outputs': [
             {
               'name': 'message',
-              'type': 0
+              'type': 'string'
             }
           ]
         },
@@ -1093,19 +1093,19 @@ export let mockResultantUIFlowWithTransformations = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': null,
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -1113,7 +1113,7 @@ export let mockResultantUIFlowWithTransformations = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },
@@ -1144,19 +1144,19 @@ export let mockResultantUIFlowWithTransformations = {
         'inputs': [
           {
             'name': 'counterName',
-            'type': 0,
+            'type': 'string',
             'value': 'counter1',
             'required': false
           },
           {
             'name': 'increment',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'reset',
-            'type': 3,
+            'type': 'boolean',
             'value': false,
             'required': false
           }
@@ -1164,7 +1164,7 @@ export let mockResultantUIFlowWithTransformations = {
         'outputs': [
           {
             'name': 'value',
-            'type': 1
+            'type': 'integer'
           }
         ]
       },
@@ -1189,19 +1189,19 @@ export let mockResultantUIFlowWithTransformations = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': 'I am here 2',
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -1209,7 +1209,7 @@ export let mockResultantUIFlowWithTransformations = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },
@@ -1234,19 +1234,19 @@ export let mockResultantUIFlowWithTransformations = {
         'inputs': [
           {
             'name': 'message',
-            'type': 0,
+            'type': 'string',
             'value': 'I am here 3',
             'required': false
           },
           {
             'name': 'flowInfo',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           },
           {
             'name': 'addToFlow',
-            'type': 3,
+            'type': 'boolean',
             'value': 'true',
             'required': false
           }
@@ -1254,7 +1254,7 @@ export let mockResultantUIFlowWithTransformations = {
         'outputs': [
           {
             'name': 'message',
-            'type': 0
+            'type': 'string'
           }
         ]
       },

--- a/src/client/flogo/flow/flow.component.ts
+++ b/src/client/flogo/flow/flow.component.ts
@@ -11,6 +11,7 @@ import { FlowData } from './core';
 import { LanguageService } from '@flogo/core';
 import { PostService } from '@flogo/core/services/post.service';
 import { OperationalError } from '@flogo/core/services/error.service';
+import { ValueTypes } from '@flogo/core/constants';
 
 import { FlogoModal } from '@flogo/core/services/modal.service';
 import { FlogoProfileService } from '@flogo/core/services/profile.service';
@@ -57,11 +58,9 @@ import { RESTAPIHandlersService } from '../core/services/restapi/v2/handlers-api
 import {
   FLOGO_FLOW_DIAGRAM_NODE_TYPE,
   FLOGO_PROFILE_TYPE,
-  FLOGO_TASK_ATTRIBUTE_TYPE,
   FLOGO_TASK_TYPE
 } from '../core/constants';
 import {
-  attributeTypeToString,
   flogoGenBranchID,
   flogoIDDecode,
   flogoIDEncode,
@@ -1354,8 +1353,8 @@ export class FlowComponent implements OnInit, OnDestroy {
       return _.map(formAttrs, (input: any) => {
         // override the value;
         return _.assign(_.cloneDeep(input), {
-          value: inputData[input['name']],
-          type: attributeTypeToString(input['type'])
+          value: inputData[input.name],
+          type: input.type
         });
       });
     }
@@ -1439,12 +1438,7 @@ export class FlowComponent implements OnInit, OnDestroy {
         // filter empty values
         return !_.isNil(item.value);
       })
-      .map((item: any) => {
-        // converting the type of the initData from enum to string;
-        const outItem = _.cloneDeep(item);
-        outItem.type = attributeTypeToString(outItem.type);
-        return outItem;
-      })
+      .map((item: any) => _.cloneDeep(item))
       .value();
   }
 
@@ -1716,7 +1710,7 @@ export class FlowComponent implements OnInit, OnDestroy {
     if (isMapperTask) {
       tile.attributes.inputs = [{
         name: 'mappings',
-        type: FLOGO_TASK_ATTRIBUTE_TYPE.ARRAY,
+        type: ValueTypes.ARRAY,
         value: _.cloneDeep(data.inputMappings)
       }];
     } else {

--- a/src/client/flogo/flow/params-schema/params-schema.component.ts
+++ b/src/client/flogo/flow/params-schema/params-schema.component.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 
 import { ModalComponent } from 'ng2-bs3-modal/ng2-bs3-modal';
 
-import { FLOGO_TASK_ATTRIBUTE_TYPE } from '@flogo/core/constants';
+import { ValueTypes } from '@flogo/core/constants';
 
 @Component({
   selector: 'flogo-flow-params-schema',
@@ -19,12 +19,11 @@ export class ParamsSchemaComponent implements OnInit {
   paramsForm: FormGroup;
   @Input() flow: any;
   @Output() save = new EventEmitter<{ input: any[], output: any[] }>();
-  selectTypes: any[] = [];
+  selectTypes: ValueTypes.ValueType[] = [];
   displayInputParams: boolean;
 
   constructor(private _fb: FormBuilder) {
-    const options = Object.keys(FLOGO_TASK_ATTRIBUTE_TYPE);
-    this.selectTypes = options.filter(o => _.isNaN(_.parseInt(o)) && o !== FLOGO_TASK_ATTRIBUTE_TYPE[FLOGO_TASK_ATTRIBUTE_TYPE.INT]);
+    this.selectTypes = Array.from(ValueTypes.allTypes);
   }
 
   ngOnInit() {
@@ -60,7 +59,7 @@ export class ParamsSchemaComponent implements OnInit {
       .filter(param => param.name && param.name.trim().length > 0)
       .map(param => ({
         name: param.name.trim(),
-        type: FLOGO_TASK_ATTRIBUTE_TYPE[_.get(param, 'type', 'STRING')],
+        type: param.type || ValueTypes.STRING,
       }));
 
     const updatedParams = this.paramsForm.value;
@@ -96,7 +95,7 @@ export class ParamsSchemaComponent implements OnInit {
   private createParamFormRow(data?: { name: string, type: string }) {
     return this._fb.group({
       name: [data ? data.name : ''],
-      type: [data ? FLOGO_TASK_ATTRIBUTE_TYPE[data.type] : 'STRING'],
+      type: [data ? data.type : 'STRING'],
     });
   }
 

--- a/src/client/flogo/flow/shared/diagram/models/flow.model.ts
+++ b/src/client/flogo/flow/shared/diagram/models/flow.model.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
 import {convertTaskID, flogoIDEncode, getDefaultValue, isSubflowTask} from '@flogo/shared/utils';
-import { FLOGO_PROCESS_TYPE, FLOGO_TASK_ATTRIBUTE_TYPE, FLOGO_TASK_TYPE } from '@flogo/core/constants';
 
 import { FLOGO_FLOW_DIAGRAM_FLOW_LINK_TYPE, FLOGO_FLOW_DIAGRAM_NODE_TYPE } from '../constants';
 import { FlowMetadata, MetadataAttribute } from '@flogo/core/interfaces/flow';
@@ -21,6 +20,9 @@ import {
   LegacyFlowWrapper,
   triggerToJSON_Trigger,
   triggerToJSON_TriggerInfo,
+  ValueTypes,
+  FLOGO_PROCESS_TYPE,
+  FLOGO_TASK_TYPE,
 } from '@flogo/core';
 
 export function triggerFlowToJSON(flow: UiFlow): triggerToJSON_Trigger {
@@ -137,8 +139,7 @@ export function flogoFlowToJSON(inFlow: UiFlow): LegacyFlowWrapper {
     flowMetadata.input = metadata.input.map(input => {
       const inputMetadata: MetadataAttribute = {
         name: input.name,
-        type: (<string>_.get(FLOGO_TASK_ATTRIBUTE_TYPE, <FLOGO_TASK_ATTRIBUTE_TYPE>_.get(input, 'type'), 'string'))
-          .toLowerCase()
+        type: input.type || ValueTypes.STRING,
       };
       if (!_.isUndefined(input.value)) {
         inputMetadata.value = input.value;
@@ -146,9 +147,8 @@ export function flogoFlowToJSON(inFlow: UiFlow): LegacyFlowWrapper {
       return inputMetadata;
     });
     flowMetadata.output = metadata.output.map(output => ({
-      name: output.name, type: (<string>_.get(FLOGO_TASK_ATTRIBUTE_TYPE,
-        <FLOGO_TASK_ATTRIBUTE_TYPE>_.get(output, 'type'),
-        'string')).toLowerCase(),
+      name: output.name,
+      type: output.type || ValueTypes.STRING,
     }));
     return flowMetadata;
   }
@@ -434,10 +434,7 @@ export function flogoFlowToJSON(inFlow: UiFlow): LegacyFlowWrapper {
       // }
 
       // the attribute default attribute type is STRING
-      attr.type = (<string>_.get(FLOGO_TASK_ATTRIBUTE_TYPE,
-        <FLOGO_TASK_ATTRIBUTE_TYPE>_.get(inAttr, 'type'),
-        'string')).toLowerCase();
-
+      attr.type = inAttr.type || ValueTypes.STRING;
 
       attributes.push(attr);
     });

--- a/src/client/flogo/flow/shared/diagram/models/task.model.ts
+++ b/src/client/flogo/flow/shared/diagram/models/task.model.ts
@@ -1,4 +1,4 @@
-import { FLOGO_ERROR_ROOT_NAME, FLOGO_TASK_ATTRIBUTE_TYPE, FLOGO_TASK_TYPE } from '@flogo/core/constants';
+import { FLOGO_ERROR_ROOT_NAME, ValueTypes, FLOGO_TASK_TYPE } from '@flogo/core/constants';
 import { flogoIDEncode } from '@flogo/shared/utils';
 import { AttributeMapping, TaskAttributes, Link, Task } from '@flogo/core';
 
@@ -76,19 +76,19 @@ export function makeDefaultErrorTrigger(id): Task {
   const outputs = [
     {
       name: 'activity',
-      type: FLOGO_TASK_ATTRIBUTE_TYPE.STRING,
+      type: ValueTypes.STRING,
       title: 'activity',
       value: ''
     },
     {
       name: 'message',
-      type: FLOGO_TASK_ATTRIBUTE_TYPE.STRING,
+      type: ValueTypes.STRING,
       title: 'message',
       value: ''
     },
     {
       name: 'data',
-      type: FLOGO_TASK_ATTRIBUTE_TYPE.ANY,
+      type: ValueTypes.ANY,
       title: 'data',
       value: ''
     }

--- a/src/client/flogo/flow/shared/dynamic-form/field-attribute.ts
+++ b/src/client/flogo/flow/shared/dynamic-form/field-attribute.ts
@@ -1,7 +1,7 @@
-import { FLOGO_TASK_ATTRIBUTE_TYPE } from '../../../core/constants';
+import { ValueTypes } from '@flogo/core';
 
 export interface FieldAttribute {
   name: string;
-  type: FLOGO_TASK_ATTRIBUTE_TYPE | string;
+  type: ValueTypes.ValueType;
   value?: any;
 }

--- a/src/client/flogo/flow/shared/dynamic-form/field-base.ts
+++ b/src/client/flogo/flow/shared/dynamic-form/field-base.ts
@@ -1,8 +1,8 @@
-import { FLOGO_TASK_ATTRIBUTE_TYPE } from '../../../core/constants';
+import { ValueTypes } from '@flogo/core';
 
 export abstract class BaseField<T> {
   name: string;
-  type: FLOGO_TASK_ATTRIBUTE_TYPE;
+  type: ValueTypes.ValueType;
   value: T;
   // making required defaulted to true only for the case of Input metadata
   required = true;
@@ -10,7 +10,7 @@ export abstract class BaseField<T> {
 
   constructor(options: {
     name?: string,
-    type?: FLOGO_TASK_ATTRIBUTE_TYPE,
+    type?: ValueTypes.ValueType,
     value?: any,
     required?: boolean,
     controlType?: string

--- a/src/client/flogo/flow/shared/dynamic-form/form-field.service.ts
+++ b/src/client/flogo/flow/shared/dynamic-form/form-field.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { FLOGO_TASK_ATTRIBUTE_TYPE } from '../../../core/constants';
+import { ValueTypes } from '@flogo/core';
 import { Textbox } from './textbox/textbox';
 import { BaseField } from './field-base';
 import { FieldAttribute } from './field-attribute';
@@ -13,49 +13,34 @@ export class FormFieldService {
 
   mapFieldsToControlType(field: FieldAttribute): BaseField<any> {
     switch (field.type) {
-      case 'string':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.STRING:
+      case ValueTypes.STRING:
         return new Textbox({
           name: field.name,
           type: field.type,
           value: field.value
         });
-
-      case 'number':
-      case 'int':
-      case 'integer':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.NUMBER:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.INT:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.INTEGER:
+      case ValueTypes.NUMBER:
+      case ValueTypes.INTEGER:
         return new NumberType({
           name: field.name,
           type: field.type,
           value: field.value
         });
-
-      case 'map':
-      case 'params':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.PARAMS:
+      case ValueTypes.PARAMS:
         return new Textarea({
           name: field.name,
           type: field.type,
           value: field.value
         });
-
-      case 'boolean':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.BOOLEAN:
+      case ValueTypes.BOOLEAN:
         return new Radio({
           name: field.name,
           type: field.type,
           value: field.value
         });
-
-      case 'object':
-      case 'any':
-      case 'complex_object':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.OBJECT:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.ANY:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.COMPLEX_OBJECT:
+      case ValueTypes.OBJECT:
+      case ValueTypes.ANY:
+      case ValueTypes.COMPLEX_OBJECT:
         return new ObjectType({
           name: field.name,
           type: field.type,

--- a/src/client/flogo/flow/shared/flows-list/flows-list.component.spec.ts
+++ b/src/client/flogo/flow/shared/flows-list/flows-list.component.spec.ts
@@ -5,6 +5,7 @@ import {SharedModule as FlogoSharedModule} from '@flogo/shared';
 import {FakeRootLanguageModule} from '@flogo/core/language/testing';
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
+import { Action } from '@flogo/core';
 
 describe('Component: FlowsListComponent', () => {
   let comp: FlowsListComponent;
@@ -64,28 +65,31 @@ describe('Component: FlowsListComponent', () => {
     firstSelectFlowButton.click();
   });
 
-  function getFlowsList() {
+  function getFlowsList(): Action[] {
     return [
       {
         'name': 'hello flow',
         'description': '',
         'id': 'flow_1',
         'createdAt': '2018-01-25T09:50:29.664Z',
-        'updatedAt': '2018-01-25T09:55:11.088Z'
+        'updatedAt': '2018-01-25T09:55:11.088Z',
+        data: {},
       },
       {
         'name': 'test flow',
         'description': 'hello',
         'id': 'flow_2',
         'createdAt': '2018-01-25T09:50:29.664Z',
-        'updatedAt': '2018-01-25T09:55:11.088Z'
+        'updatedAt': '2018-01-25T09:55:11.088Z',
+        data: {},
       },
       {
         'name': 'flow something',
         'description': '',
         'id': 'flow_3',
         'createdAt': '2018-01-25T09:50:29.664Z',
-        'updatedAt': '2018-01-25T09:55:11.088Z'
+        'updatedAt': '2018-01-25T09:55:11.088Z',
+        data: {},
       }
     ];
   }

--- a/src/client/flogo/flow/shared/form-builder/configuration/shared/configuration-common.service.ts
+++ b/src/client/flogo/flow/shared/form-builder/configuration/shared/configuration-common.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {FLOGO_TASK_ATTRIBUTE_TYPE} from '@flogo/core/constants';
+import { ValueTypes } from '@flogo/core/constants';
 
 @Injectable()
 export class FlogoConfigurationCommonService {
@@ -26,71 +26,31 @@ export class FlogoConfigurationCommonService {
     return obj;
   }
 
-  _mapTypeToConstant(type: string|FLOGO_TASK_ATTRIBUTE_TYPE): FLOGO_TASK_ATTRIBUTE_TYPE {
-    switch (type) {
-      case 'string':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.STRING:
-        return FLOGO_TASK_ATTRIBUTE_TYPE.STRING;
-
-      case 'number':
-      case 'int':
-      case 'integer':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.NUMBER:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.INT:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.INTEGER:
-        return FLOGO_TASK_ATTRIBUTE_TYPE.NUMBER;
-
-      case 'boolean':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.BOOLEAN:
-        return FLOGO_TASK_ATTRIBUTE_TYPE.BOOLEAN;
-
-      case 'object':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.OBJECT:
-        return FLOGO_TASK_ATTRIBUTE_TYPE.OBJECT;
-
-      case 'map':
-      case 'params':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.PARAMS:
-        return FLOGO_TASK_ATTRIBUTE_TYPE.PARAMS;
-
-      case 'any':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.ANY:
-            return FLOGO_TASK_ATTRIBUTE_TYPE.ANY;
-
-      case 'complex_object':
-      case FLOGO_TASK_ATTRIBUTE_TYPE.COMPLEX_OBJECT:
-        return FLOGO_TASK_ATTRIBUTE_TYPE.COMPLEX_OBJECT;
-
-      default:
-        return FLOGO_TASK_ATTRIBUTE_TYPE.STRING;
-    }
-  }
-
   getControlByType(item: any, paramDirection?: string) {
     let control = '';
-    const typeAsConstant: FLOGO_TASK_ATTRIBUTE_TYPE = this._mapTypeToConstant(item.type);
+    const typeAsConstant = item.type as ValueTypes.ValueType;
 
     switch (typeAsConstant) {
-      case  FLOGO_TASK_ATTRIBUTE_TYPE.STRING:
+      case  ValueTypes.STRING:
         control =  'FieldTextBox';
         break;
 
-      case FLOGO_TASK_ATTRIBUTE_TYPE.NUMBER:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.INTEGER:
+      case ValueTypes.NUMBER:
+      case ValueTypes.INTEGER:
         control = 'FieldNumber';
         break;
 
-      case FLOGO_TASK_ATTRIBUTE_TYPE.BOOLEAN:
+      case ValueTypes.BOOLEAN:
         control = 'FieldRadio';
         break;
 
-      case FLOGO_TASK_ATTRIBUTE_TYPE.PARAMS:
+      case ValueTypes.PARAMS:
         control = 'FieldTextArea';
         break;
 
-      case FLOGO_TASK_ATTRIBUTE_TYPE.ANY:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.OBJECT:
-      case FLOGO_TASK_ATTRIBUTE_TYPE.COMPLEX_OBJECT:
+      case ValueTypes.ANY:
+      case ValueTypes.OBJECT:
+      case ValueTypes.COMPLEX_OBJECT:
         control = 'FieldObject';
         break;
 
@@ -99,7 +59,7 @@ export class FlogoConfigurationCommonService {
         break;
     }
 
-    if (paramDirection === this.directions.output && item.type === FLOGO_TASK_ATTRIBUTE_TYPE.STRING) {
+    if (paramDirection === this.directions.output && item.type === ValueTypes.STRING) {
       control = 'FieldObject';
     }
 

--- a/src/client/flogo/flow/shared/form-builder/fields/listbox/listbox.component.ts
+++ b/src/client/flogo/flow/shared/form-builder/fields/listbox/listbox.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { LanguageService, ValueTypes } from '@flogo/core';
+
 import { FlogoFormBuilderFieldsBaseComponent } from '../shared/base.component';
-import { DEFAULT_VALUES_OF_TYPES as DEFAULT_VALUES } from '@flogo/core/constants';
-import { LanguageService } from '@flogo/core';
 
 const EMPTY_OPTION = '<empty>';
 
@@ -30,7 +30,7 @@ export class FlogoFormBuilderFieldsListBoxComponent extends FlogoFormBuilderFiel
 
   onChangeField(option: string) {
     if (option === EMPTY_OPTION) {
-      option = DEFAULT_VALUES[this._info.type];
+      option = ValueTypes.defaultValueForType.get(this._info.type);
     }
     this._info.value = option;
     this.publishNextChange();

--- a/src/client/flogo/flow/shared/form-builder/form-builder.spec.ts
+++ b/src/client/flogo/flow/shared/form-builder/form-builder.spec.ts
@@ -35,12 +35,12 @@ class TaskTestHostComponent {
         activityType: 'tibco-log',
         attributes: {
           inputs: [
-            {name: 'message', type: 0, value: 'Received request.'},
-            {name: 'flowInfo', type: 3, value: 'true'},
-            {name: 'addToFlow', type: 3, value: 'true'}
+            {name: 'message', type: 'string', value: 'Received request.'},
+            {name: 'flowInfo', type: 'boolean', value: 'true'},
+            {name: 'addToFlow', type: 'boolean', value: 'true'}
           ],
           outputs: [
-            {name: 'message', type: 0}
+            {name: 'message', type: 'string'}
           ]
         },
         description: 'Simple Log Activity',
@@ -94,9 +94,9 @@ class TriggerTestHostComponent {
             {name: 'useReplyHandler', type: 'boolean', value: 'true'}]},
         homepage: '', id: '', installed: true, name: 'Receiver',
         outputs: [
-          {name: 'pathParams', type: 6, value: {q: 100}},
-          {name: 'queryParams', type: 6, value: {status: 1}},
-          {name: 'content', type: 4, value: '400'}],
+          {name: 'pathParams', type: 'params', value: {q: 100}},
+          {name: 'queryParams', type: 'params', value: {status: 1}},
+          {name: 'content', type: 'object', value: '400'}],
         settings: [{name: 'port', required: true, type: 'integer', value: '9999'}],
         title: 'REST Trigger', triggerType: 'tibco-rest', type: 0, version: '0.0.1', where: ''
       };

--- a/src/client/flogo/flow/shared/mapper/utils/mapper-translator.ts
+++ b/src/client/flogo/flow/shared/mapper/utils/mapper-translator.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { resolveExpressionType } from '@flogo/packages/mapping-parser';
 
-import { FLOGO_ERROR_ROOT_NAME, FLOGO_TASK_ATTRIBUTE_TYPE, FLOGO_TASK_TYPE } from '@flogo/core/constants';
+import { FLOGO_ERROR_ROOT_NAME, FLOGO_TASK_TYPE, ValueTypes } from '@flogo/core/constants';
 import { Task as FlowTile, AttributeMapping as FlowMapping, } from '@flogo/core';
 import { MAPPING_TYPE, REGEX_INPUT_VALUE_EXTERNAL } from '../constants';
 
@@ -62,12 +62,12 @@ export class MapperTranslator {
   }
 
   static attributesToObjectDescriptor(attributes: {
-    name: string, type: string | FLOGO_TASK_ATTRIBUTE_TYPE, required?: boolean
+    name: string, type: ValueTypes.ValueType, required?: boolean
   }[], additionalProps?: { [key: string]: any }): MapperSchema {
     const properties = {};
     const requiredPropertyNames = [];
     attributes.forEach(attr => {
-      let property = {type: MapperTranslator.translateType(attr.type)};
+      let property = { type: attr.type };
       if (additionalProps) {
         property = Object.assign({}, additionalProps, property);
       }
@@ -77,23 +77,6 @@ export class MapperTranslator {
       }
     });
     return {type: 'object', properties: sortObjectKeys(properties), required: requiredPropertyNames};
-  }
-
-  // todo: change
-  static translateType(type: FLOGO_TASK_ATTRIBUTE_TYPE | string) {
-    const translatedType = {
-      [FLOGO_TASK_ATTRIBUTE_TYPE.ANY]: 'any',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.ARRAY]: 'array',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.BOOLEAN]: 'boolean',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.INT]: 'integer',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.INTEGER]: 'integer',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.NUMBER]: 'number',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.OBJECT]: 'object',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.PARAMS]: 'object',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.STRING]: 'string',
-      [FLOGO_TASK_ATTRIBUTE_TYPE.COMPLEX_OBJECT]: 'complex_object',
-    }[type];
-    return translatedType || type;
   }
 
   static translateMappingsIn(inputMappings: FlowMapping[]) {

--- a/src/client/flogo/flow/task-add/mocks/tasks.ts
+++ b/src/client/flogo/flow/task-add/mocks/tasks.ts
@@ -1,4 +1,4 @@
-import { FLOGO_TASK_TYPE, FLOGO_TASK_ATTRIBUTE_TYPE } from '@flogo/core/constants';
+import { FLOGO_TASK_TYPE, ValueTypes } from '@flogo/core/constants';
 import { flogoIDEncode } from '@flogo/shared/utils';
 
 export let MOCK_TASKS = [
@@ -10,13 +10,13 @@ export let MOCK_TASKS = [
     'attributes' : {
       'inputs' : [
         {
-          'type' : FLOGO_TASK_ATTRIBUTE_TYPE.STRING,
+          'type' : ValueTypes.STRING,
           'name' : 'message',
           'title' : 'Message',
           'value' : 'Find Pet Process Started!'
         },
         {
-          'type' : FLOGO_TASK_ATTRIBUTE_TYPE.BOOLEAN,
+          'type' : ValueTypes.BOOLEAN,
           'name' : 'processInfo',
           'title' : 'Process info',
           'value' : 'true'
@@ -32,19 +32,19 @@ export let MOCK_TASKS = [
     'attributes' : {
       'inputs' : [
         {
-          'type' : FLOGO_TASK_ATTRIBUTE_TYPE.STRING,
+          'type' : ValueTypes.STRING,
           'name' : 'uri',
           'title' : 'URI',
           'value' : 'http://petstore.swagger.io/v2/pet/{petId}'
         },
         {
-          'type' : FLOGO_TASK_ATTRIBUTE_TYPE.STRING,
+          'type' : ValueTypes.STRING,
           'name' : 'method',
           'title' : 'Method',
           'value' : 'GET'
         },
         {
-          'type' : FLOGO_TASK_ATTRIBUTE_TYPE.STRING,
+          'type' : ValueTypes.STRING,
           'name' : 'petId',
           'title' : 'Pet ID',
           'value' : '201603311111'
@@ -52,7 +52,7 @@ export let MOCK_TASKS = [
       ],
       'outputs' : [
         {
-          'type' : FLOGO_TASK_ATTRIBUTE_TYPE.OBJECT,
+          'type' : ValueTypes.OBJECT,
           'name' : 'result',
           'title' : 'Result',
           'value' : ''
@@ -82,13 +82,13 @@ export let MOCK_TASKS = [
     'attributes' : {
       'inputs' : [
         {
-          'type' : FLOGO_TASK_ATTRIBUTE_TYPE.STRING,
+          'type' : ValueTypes.STRING,
           'name' : 'message',
           'title' : 'Message',
           'value' : 'REST results'
         },
         {
-          'type' : FLOGO_TASK_ATTRIBUTE_TYPE.BOOLEAN,
+          'type' : ValueTypes.BOOLEAN,
           'name' : 'processInfo',
           'title' : 'Process Info',
           'value' : 'true'

--- a/src/client/flogo/flow/task-configurator/models/flow-metadata.ts
+++ b/src/client/flogo/flow/task-configurator/models/flow-metadata.ts
@@ -1,5 +1,7 @@
+import { ValueTypes } from '@flogo/core/constants';
+
 export interface FlowMetadata {
   type: 'metadata';
-  input: Array<{ name: string; type: string; }>;
-  output: Array<{ name: string; type: string; }>;
+  input: Array<{ name: string; type: ValueTypes.ValueType; }>;
+  output: Array<{ name: string; type: ValueTypes.ValueType; }>;
 }

--- a/src/client/flogo/flow/task-configurator/task-configurator.component.spec.ts
+++ b/src/client/flogo/flow/task-configurator/task-configurator.component.spec.ts
@@ -7,9 +7,10 @@ import { CommonModule as NgCommonModule } from '@angular/common';
 import { TaskConfiguratorComponent } from './task-configurator.component';
 import { MapperModule } from '../shared/mapper';
 import { FakeRootLanguageModule } from '@flogo/core/language/testing';
-import { SaveTaskConfigEventData, SelectTaskConfigEventData } from '@flogo/flow/task-configurator/messages';
+import { SelectTaskConfigEventData } from '@flogo/flow/task-configurator/messages';
 import { InputMapperComponent } from './input-mapper';
 import { IteratorComponent } from './iterator/iterator.component';
+import { ValueTypes } from '@flogo/core';
 
 const postServiceStub = {
 
@@ -86,12 +87,12 @@ describe('Component: TaskConfiguratorComponent', () => {
           'outputs': [
             {
               'name': 'params',
-              'type': 6,
+              'type': ValueTypes.PARAMS,
               'value': null
             },
             {
               'name': 'content',
-              'type': 4,
+              'type': ValueTypes.OBJECT,
               'value': null
             }
           ],
@@ -134,25 +135,25 @@ describe('Component: TaskConfiguratorComponent', () => {
             'inputs': [
               {
                 'name': 'counterName',
-                'type': 0,
+                'type': ValueTypes.STRING,
                 'required': true,
                 'value': 'number'
               },
               {
                 'name': 'increment',
-                'type': 3,
+                'type': ValueTypes.BOOLEAN,
                 'value': 'true'
               },
               {
                 'name': 'reset',
-                'type': 3,
+                'type': ValueTypes.BOOLEAN,
                 'value': 'false'
               }
             ],
             'outputs': [
               {
                 'name': 'value',
-                'type': 1
+                'type': ValueTypes.INTEGER,
               }
             ]
           },
@@ -170,24 +171,24 @@ describe('Component: TaskConfiguratorComponent', () => {
           'inputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': ValueTypes.STRING,
               'value': 'hello world'
             },
             {
               'name': 'flowInfo',
-              'type': 3,
+              'type': ValueTypes.BOOLEAN,
               'value': 'true'
             },
             {
               'name': 'addToFlow',
-              'type': 3,
+              'type': ValueTypes.BOOLEAN,
               'value': 'true'
             }
           ],
           'outputs': [
             {
               'name': 'message',
-              'type': 0,
+              'type': ValueTypes.STRING,
               value: ''
             }
           ]

--- a/src/client/flogo/shared/utils.ts
+++ b/src/client/flogo/shared/utils.ts
@@ -1,5 +1,4 @@
-import { DEFAULT_VALUES_OF_TYPES, FLOGO_TASK_ATTRIBUTE_TYPE, FLOGO_TASK_TYPE } from '../core/constants';
-import {FLOGO_PROFILE_TYPE} from '@flogo/core/constants';
+import { ValueTypes, FLOGO_TASK_TYPE, FLOGO_PROFILE_TYPE } from '@flogo/core/constants';
 
 // URL safe base64 encoding
 // reference: https://gist.github.com/jhurliman/1250118
@@ -62,8 +61,8 @@ export function convertTaskID(taskID: string) {
 }
 
 // get default value of a given type
-export function getDefaultValue(type: FLOGO_TASK_ATTRIBUTE_TYPE): any {
-  return DEFAULT_VALUES_OF_TYPES[type];
+export function getDefaultValue(forType: ValueTypes.ValueType): any {
+  return ValueTypes.defaultValueForType.get(forType);
 }
 
 // convert the type of attribute and add default value if enabled
@@ -78,10 +77,6 @@ function portAttribute(inAttr: {
     value: any;
     [key: string]: any;
   }>_.assign({}, inAttr);
-
-  outAttr.type = <FLOGO_TASK_ATTRIBUTE_TYPE>_.get(FLOGO_TASK_ATTRIBUTE_TYPE,
-    _.get(outAttr, 'type', 'STRING')
-      .toUpperCase());
 
   if (withDefault && _.isUndefined(outAttr.value)) {
     outAttr.value = getDefaultValue(outAttr.type);
@@ -404,14 +399,6 @@ export function notification(message: string, type: string, time?: number, setti
       resolve();
     }
   });
-}
-
-export function attributeTypeToString(inType: any): string {
-  if (_.isString(inType)) {
-    return inType;
-  }
-
-  return (FLOGO_TASK_ATTRIBUTE_TYPE[inType] || 'string').toLowerCase();
 }
 
 /**


### PR DESCRIPTION
Simplify attribute type handling in the UI by removing the use of the the `FLOGO_TASK_ATTRIBUTE_TYPE` enum and use the same string constants as the engine.

This eliminates the need for data transformations between the client application and backend model.