### PR TITLE
654 - API changes to get subflow related data

### DIFF
--- a/src/server/api/v2/actions.js
+++ b/src/server/api/v2/actions.js
@@ -32,7 +32,7 @@ function* listActions() {
   }
 
   if (getFields) {
-    options.payload = getFields.split(',');
+    options.project = getFields.split(',');
   }
 
   const actionList = yield ActionsManager.list(appId, options);

--- a/src/server/modules/actions/index.js
+++ b/src/server/modules/actions/index.js
@@ -136,7 +136,7 @@ export class ActionsManager {
         }
         return actions;
       })
-      .then(actions => projectOutputOnFields(actions, options.payload));
+      .then(actions => projectOutputOnFields(actions, options.project));
   }
 
   static listRecent() {


### PR DESCRIPTION
Fixes #654 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently there is no API call which can give proper response for supporting subflow details. In order to get the flow details of a subflow in a main flow, we end up calling getFlow api call for each flowId.


**What is the new behavior?**
We made changes to `api/v2/apps/:appId/actions` such that it allows following query params:

1. filter[name]=:stringFlowName 
2. filter[id]=:csvOfFlowIds
3. fields=:csvOfFlowFieldsNeededInOutput

The URL can have either `filter[name]` or `filter[id]`. If both provided, the filter by name is taken precedence. The optional query param `fields` will allow to pick only the required fields of the action JSON in the response. 

Now we can do : 

- `/api/v2/apps/:appId/actions?fields=name,description,metadata,id,createdAt&filter[id]=:flowId1,:flowId2`
- `/api/v2/apps/:appId/actions?fields=name,description&filter[name]=flowName`