### PR TITLE
[639 - 5] - Able to show subflow's output in available data for configuring other activities

### DIFF
--- a/src/client/flogo/flow/flow.component.ts
+++ b/src/client/flogo/flow/flow.component.ts
@@ -1788,7 +1788,12 @@ export class FlowComponent implements OnInit, OnDestroy {
       .map(nodeId => {
         const node = from.diagram.nodes[nodeId];
         if (isApplicableNodeType(node.type)) {
-          return from.tasks[node.taskID];
+          const task = from.tasks[node.taskID];
+          if (isSubflowTask(task.type)) {
+            const subFlowSchema = this._flowService.currentFlowDetails.getSubflowSchema(task.flowRef);
+            task.attributes.outputs = _.get(subFlowSchema, 'metadata.output', []);
+          }
+          return task;
         } else {
           return null;
         }

--- a/src/client/flogo/flow/shared/mapper/utils/mapper-translator.ts
+++ b/src/client/flogo/flow/shared/mapper/utils/mapper-translator.ts
@@ -30,7 +30,9 @@ export class MapperTranslator {
       if (tile.type !== 'metadata') {
         const attributes = tile.attributes;
         let outputs;
-        if (tile.type === FLOGO_TASK_TYPE.TASK || tile.type === FLOGO_TASK_TYPE.TASK_ITERATOR) {
+        if (tile.type === FLOGO_TASK_TYPE.TASK
+          || tile.type === FLOGO_TASK_TYPE.TASK_ITERATOR
+          || tile.type === FLOGO_TASK_TYPE.TASK_SUB_PROC) {
           // try to get data from task from outputs
           outputs = attributes && attributes.outputs ? attributes.outputs : [];
         } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

5th part of #639 

I am now able to show subflow's (which fall in the activities path) output under the available data while configuring the input mappings of another activity 