### PR TITLE
[quick-fix] Removing performance api dependencies from ui converter model

### DIFF
--- a/src/client/flogo/flow/core/models/ui-converter.model.ts
+++ b/src/client/flogo/flow/core/models/ui-converter.model.ts
@@ -379,13 +379,7 @@ class NodeFactory {
   }
 
   static flogoGenBranchID() {
-    let id = '';
-
-    if (performance && _.isFunction(performance.now)) {
-      id = `Flogo::Branch::${Date.now()}::${performance.now()}`;
-    } else {
-      id = `Flogo::Branch::${Date.now()}`;
-    }
+    const id = `Flogo::Branch::${Date.now()}::${FlogoFlowDiagramNode.count++}`;
     return flogoIDEncode(id);
   }
 }

--- a/src/client/flogo/flow/flow-data.resolver.ts
+++ b/src/client/flogo/flow/flow-data.resolver.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
 import { FlogoFlowService } from '@flogo/flow/core';
 import { FlowData } from './core';
+import {FlogoFlowDiagramNode} from '@flogo/flow/shared/diagram/models';
 
 @Injectable()
 export class FlowDataResolver implements Resolve<FlowData> {
@@ -10,6 +11,7 @@ export class FlowDataResolver implements Resolve<FlowData> {
 
   resolve(route: ActivatedRouteSnapshot) {
     const flowId = route.params['id'];
+    FlogoFlowDiagramNode.resetCount();
     return this.flowService.loadFlow(flowId);
   }
 

--- a/src/client/flogo/flow/shared/diagram/models/node.model.ts
+++ b/src/client/flogo/flow/shared/diagram/models/node.model.ts
@@ -4,6 +4,8 @@ import { FLOGO_FLOW_DIAGRAM_NODE_TYPE, FLOGO_FLOW_DIAGRAM_VERBOSE as VERBOSE } f
 import { Node } from '@flogo/core/interfaces/flow-diagram/node';
 
 export class FlogoFlowDiagramNode implements Node {
+  static count = 1;
+
   id: string; // id of the node
   taskID: string; // id of the task
   type: FLOGO_FLOW_DIAGRAM_NODE_TYPE; // type of the node
@@ -12,15 +14,12 @@ export class FlogoFlowDiagramNode implements Node {
   // subProc: FlowDiagram[ ]; // [optional] sub process diagram of a task with sub process
 
   static genNodeID(): string {
-    let id = '';
-
-    if (performance && _.isFunction(performance.now)) {
-      id = `FlogoFlowDiagramNode::${Date.now()}::${performance.now()}`;
-    } else {
-      id = `FlogoFlowDiagramNode::${Date.now()}}`;
-    }
-
+    const id = `FlogoFlowDiagramNode::${Date.now()}::${FlogoFlowDiagramNode.count++}`;
     return flogoIDEncode(id);
+  }
+
+  static resetCount() {
+    FlogoFlowDiagramNode.count = 1;
   }
 
   constructor(node ?: Node) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

We are depending on `window.performance.now()` to generate a unique node ID in ui-converter model. But the latest chrome update to 64 has modified the performance api for which we are unable to generate a unique node id. 

We now are removing the dependency on performance api and using a unique counter.
