### PR TITLE
Fix: mappings to subflow activities are not exported

### DIFF
--- a/src/server/modules/exporter/utils/dangling-subflow-references-cleaner.js
+++ b/src/server/modules/exporter/utils/dangling-subflow-references-cleaner.js
@@ -13,11 +13,11 @@ export class DanglingSubflowReferencesCleaner {
       return [];
     }
 
-    const mappedPropNamesInTask = task.inputMappings.map(mapping => mapping.name);
+    const mappedPropNamesInTask = task.inputMappings.map(mapping => mapping.mapTo);
     const linkedFlowInputNames = linkedFlowInputMetadata.map(input => input.name);
     const finalMappingNames = intersection(mappedPropNamesInTask, linkedFlowInputNames);
 
-    return task.inputMappings.filter(inputMapping => finalMappingNames.includes(inputMapping.name));
+    return task.inputMappings.filter(inputMapping => finalMappingNames.includes(inputMapping.mapTo));
   }
 
   getFlowMetadata(linkedFlow) {

--- a/src/server/modules/exporter/utils/dangling-subflow-references-cleaner.spec.js
+++ b/src/server/modules/exporter/utils/dangling-subflow-references-cleaner.spec.js
@@ -4,9 +4,9 @@ import { DanglingSubflowReferencesCleaner } from './dangling-subflow-references-
 describe('exporter.utils.DanglingSubflowReferencesCleaner', function () {
   const task = {
     inputMappings: [
-      { name: 'foo', value: 'oof', type: 2 },
-      { name: 'dangling', value: 'abcd', type: 2 },
-      { name: 'bar', value: 'rab', type: 2 },
+      { mapTo: 'foo', value: 'oof', type: 2 },
+      { mapTo: 'dangling', value: 'abcd', type: 2 },
+      { mapTo: 'bar', value: 'rab', type: 2 },
     ],
   };
   const linkedFlow = {
@@ -25,8 +25,8 @@ describe('exporter.utils.DanglingSubflowReferencesCleaner', function () {
   it('valid mappings should stay', function () {
     expect(cleanMappings).to.have.length(2)
       .and.to.deep.include.members([
-        { name: 'foo', value: 'oof', type: 2 },
-        { name: 'bar', value: 'rab', type: 2 },
+        { mapTo: 'foo', value: 'oof', type: 2 },
+        { mapTo: 'bar', value: 'rab', type: 2 },
       ]);
   });
 });


### PR DESCRIPTION
Input mappings of a subflow task were not being exported.
