### PR TITLE
Fix mappings using error handler were not correctly generated.

### DIFF
--- a/src/client/flogo/flow/shared/diagram/models/task.model.ts
+++ b/src/client/flogo/flow/shared/diagram/models/task.model.ts
@@ -91,6 +91,12 @@ export function makeDefaultErrorTrigger(id): Task {
       type: ValueTypes.ANY,
       title: 'data',
       value: ''
+    },
+    {
+      name: 'code',
+      type: ValueTypes.STRING,
+      title: 'code',
+      value: ''
     }
   ];
 

--- a/src/client/flogo/flow/shared/mapper/constants.ts
+++ b/src/client/flogo/flow/shared/mapper/constants.ts
@@ -10,5 +10,12 @@ export const MAPPING_TYPE = {
   OBJECT_TEMPLATE: TYPE_OBJECT_TEMPLATE,
 };
 
+export const ROOT_TYPES = {
+  FLOW: 'flow',
+  ACTIVITY: 'activity',
+  TRIGGER: 'trigger',
+  ERROR: 'error',
+};
+
 export const REGEX_INPUT_VALUE_INTERNAL = /^(([\w-]+)\.([\w-]+))((?:\.[\w-]+)*)$/;
 export const REGEX_INPUT_VALUE_EXTERNAL = /^\{(A([\w-]+)|T|E)\.([\w-]+)\}((?:\.[\w-]+)*)$/;

--- a/src/client/flogo/flow/shared/mapper/index.ts
+++ b/src/client/flogo/flow/shared/mapper/index.ts
@@ -1,5 +1,6 @@
 export * from './mapper.module';
 export * from './mapper.component';
+export * from './constants';
 
 export { IMapping, IMapExpression, Mappings } from './models';
 export { MapperTranslator, MappingsValidatorFn, StaticMapperContextFactory } from './utils';

--- a/src/client/flogo/flow/shared/mapper/services/mapper.service.ts
+++ b/src/client/flogo/flow/shared/mapper/services/mapper.service.ts
@@ -28,7 +28,7 @@ import { MapperTreeNode } from '../models/mapper-treenode.model';
 
 import { ArrayMappingHelper, ArrayMappingInfo } from '../models/array-mapping';
 import { IParsedExpressionDetails, IMapperContext } from '../models';
-import { TYPE_ATTR_ASSIGNMENT } from '../constants';
+import { TYPE_ATTR_ASSIGNMENT, ROOT_TYPES } from '../constants';
 
 export interface TreeState {
   filterTerm: string | null;
@@ -435,13 +435,13 @@ export class MapperService {
     const resolver = root.data.rootType;
     const makeResolvable = expr => '$' + expr;
 
-    if (resolver === 'trigger') {
+    if (resolver === ROOT_TYPES.TRIGGER || resolver === ROOT_TYPES.ERROR) {
       expressionHead = `${resolver}.`;
       expressionHead += propName ? propName.data.nodeName : '';
       expressionHead = makeResolvable(expressionHead);
       expressionTailParts = nodes.slice(2);
-    } else if (resolver === 'activity') {
-      expressionHead = `activity[${root.data.nodeName}].`;
+    } else if (resolver === ROOT_TYPES.ACTIVITY) {
+      expressionHead = `${ROOT_TYPES.ACTIVITY}[${root.data.nodeName}].`;
       expressionHead += propName ? propName.data.nodeName : '';
       expressionHead = makeResolvable(expressionHead);
       expressionTailParts = nodes.slice(2);


### PR DESCRIPTION
Expressions were incorrectly generated as described in #700, they should follow the format `$error.<propName>` ex. `$error.name`

Following TIBCOSoftware/flogo-contrib#226 also made available property 'code' for mapping.
