### PR TITLE
Enabling runflow when subflow/iterator donot exist in a flow.

### DIFF
--- a/src/client/flogo/flow/flow.component.ts
+++ b/src/client/flogo/flow/flow.component.ts
@@ -1441,6 +1441,9 @@ export class FlowComponent implements OnInit, OnDestroy {
     if (subflowOrIteratorTasks) {
       this.runnableInfo.disabled = true;
       this.runnableInfo.disableReason = this.translate.instant('CANVAS:WARNING-UNSUPPORTED-TEST-RUN');
+    } else {
+      this.runnableInfo.disabled = false;
+      this.runnableInfo.disableReason = null;
     }
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Adding subflow/iterator to a flow was disabling the "Run Flow" ,but it was not getting enabled when they were deleted from the flow. 


**What is the new behavior?**
Run Flow is getting enabled when subflow/iterator donot exist in a flow.
**Other information**:
