### PR TITLE
Fix UI is not loading in Safari.

### DIFF
--- a/src/client/flogo/logs/content/content.component.html
+++ b/src/client/flogo/logs/content/content.component.html
@@ -28,7 +28,7 @@
 
     </div>
 
-    <div class="flogo-logs-lines" [style.overflow-y]="isExternal ? 'none' : 'scroll'">
+    <div class="flogo-logs-lines" [style.overflow-y]="isExternal ? 'none' : 'auto'">
         <div class="content-section">
             <div *ngFor="let message of logService.lines | flogoLogsSearch : searchValue" class="log-line">
                 <div class="log-line__timestamp">{{message.timestamp}}</div>

--- a/src/client/flogo/shared/directives/draggable.directive.ts
+++ b/src/client/flogo/shared/directives/draggable.directive.ts
@@ -34,7 +34,9 @@ export class DraggableDirective implements OnDestroy, OnInit {
       this.dragItem = event.target['cloneNode'](true);
       this.dragItem.style.visibility = 'hidden';
       document.body.appendChild(this.dragItem);
-      event.dataTransfer['setDragImage'](this.dragItem, 0, 0);
+      if (event.dataTransfer['setDragImage']) { // IE Edge does not support setDragImage
+        event.dataTransfer['setDragImage'](this.dragItem, 0, 0);
+      }
 
       this.Δx = event.x - this.el.nativeElement.offsetLeft;
       this.Δy = event.y - this.el.nativeElement.offsetTop;


### PR DESCRIPTION
Use Event instead of DragEvent.

Angular/typescript outputs the use of the class `DragEvent` but `DragEvent` is not available in Safari which causes an error: `Error: Can't find variable: DragEvent` that prevents the application from starting.