### PR TITLE
Fix JS Error in IE Edge browser for unavailable setDragImage method

### DIFF
--- a/src/client/flogo/logs/content/content.component.html
+++ b/src/client/flogo/logs/content/content.component.html
@@ -28,7 +28,7 @@
 
     </div>
 
-    <div class="flogo-logs-lines" [style.overflow-y]="isExternal ? 'none' : 'scroll'">
+    <div class="flogo-logs-lines" [style.overflow-y]="isExternal ? 'none' : 'auto'">
         <div class="content-section">
             <div *ngFor="let message of logService.lines | flogoLogsSearch : searchValue" class="log-line">
                 <div class="log-line__timestamp">{{message.timestamp}}</div>

--- a/src/client/flogo/shared/directives/draggable.directive.ts
+++ b/src/client/flogo/shared/directives/draggable.directive.ts
@@ -34,7 +34,9 @@ export class DraggableDirective implements OnDestroy, OnInit {
       this.dragItem = event.target['cloneNode'](true);
       this.dragItem.style.visibility = 'hidden';
       document.body.appendChild(this.dragItem);
-      event.dataTransfer['setDragImage'](this.dragItem, 0, 0);
+      if (event.dataTransfer['setDragImage']) { // IE Edge does not support setDragImage
+        event.dataTransfer['setDragImage'](this.dragItem, 0, 0);
+      }
 
       this.Δx = event.x - this.el.nativeElement.offsetLeft;
       this.Δy = event.y - this.el.nativeElement.offsetTop;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
In IE Edge we see the following error in the console when we start dragging the log window:
```
ERROR TypeError: Object doesn't support property or method 'setDragImage'
Function code (37) (5,3)
   "ERROR"
   {
      [functions]: ,
      __proto__: { },
      description: "Object doesn't support property or method 'setDragImage'",
      message: "Object doesn't support property or method 'setDragImage'",
      name: "TypeError",
      ngDebugContext: { },
      number: -2146827850,
      stack: "TypeError: Object doesn't support property or method 'setDragImage'
   at DraggableDirective.prototype.onDragStart (eval code:42:13)
   at Anonymous function (Function code:10:7)
   at handleEvent (eval code:13763:87)
   at callWithDebugContext (eval code:15272:9)
   at debugHandleEvent (eval code:14859:5)
   at dispatchEvent (eval code:10178:9)
   at Anonymous function (eval code:10803:31)
   at Anonymous function (eval code:2680:9)
   at ZoneDelegate.prototype.invokeTask (eval code:419:13)
   at onInvokeTask (eval code:4956:17)"
   }
```

Also made small improvement to show the scrollbar to the log window by changing the overflow-y to `auto` instead of `scroll`