### PR TITLE
Fix parser got stuck because of regex with too many options

### DIFF
--- a/src/client/flogo/packages/mapping-parser/parser/parser.ts
+++ b/src/client/flogo/packages/mapping-parser/parser/parser.ts
@@ -80,7 +80,7 @@ const Colon = createToken({
 const StringLiteral = createToken({
   name: 'StringLiteral',
   label: 'StringLiteral',
-  pattern: /"(:?[^\\"\n\r]+|\\(:?[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/,
+  pattern: /"(?:[^\\"]|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/,
 });
 
 const NumberLiteral = createToken({


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**
Unterminated strings in an expression can cause the parser to get stuck due to a regular expression that has too many options to parse. 

For example pasting the following expression in the input mapper will freeze the browser window:
```
{
“someProp”: "{{$activity[rest_1].result.json.path[0].property}}”
}
```

**What is the new behavior?**
The browser doesn't get stuck anymore.