### PR TITLE
Fix issue with errors modal while importing the application - #735

### DIFF
--- a/src/client/flogo/home/app-import/app-import.component.ts
+++ b/src/client/flogo/home/app-import/app-import.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
+import {AfterViewInit, Component, EventEmitter, Input, OnChanges, Output, ViewChild} from '@angular/core';
 import { BsModalComponent } from 'ng2-bs3-modal';
 import { ImportErrorFormatterService } from '../core/import-error-formatter.service';
 import {ValidationDetail} from '@flogo/core';
@@ -9,7 +9,7 @@ import {ValidationDetail} from '@flogo/core';
   templateUrl: 'app-import.component.html',
   styleUrls: ['app-import.component.less']
 })
-export class FlogoAppImportComponent implements OnChanges {
+export class FlogoAppImportComponent implements OnChanges, AfterViewInit {
 
   @ViewChild('errorModal') modal: BsModalComponent;
 
@@ -24,6 +24,9 @@ export class FlogoAppImportComponent implements OnChanges {
 
   ngOnChanges(changes: any) {
     this.errorDetails = this.errorFormatter.getErrorsDetails(this.importValidationErrors);
+  }
+
+  ngAfterViewInit() {
     this.openModal();
   }
 


### PR DESCRIPTION
Fixes #735 

After upgrading to ng5, We need to be cautious about the way we are opening and closing the modal window. In app-import component, the modal was trying to open the window in ngOnChanges lifecycle hook but the view for that was not yet initialized which caused this problem. Moved the modal opening inside the afterview init.