### PR TITLE
Fix save is disable if updating object mapping.

### DIFF
--- a/src/client/flogo/flow/shared/mapper/utils/mapper-translator.ts
+++ b/src/client/flogo/flow/shared/mapper/utils/mapper-translator.ts
@@ -178,17 +178,7 @@ function isInvalidMapping(mapping: IMapExpression) {
   if (!expression || !expression.trim().length) {
     return false;
   }
-  let isInvalid = false;
-  if (mapping.mappingType === MAPPING_TYPE.OBJECT_TEMPLATE) {
-    try {
-      JSON.parse(expression);
-    } catch (e) {
-      isInvalid = true;
-    }
-  } else {
-    return !isValidExpression(expression);
-  }
-  return isInvalid;
+  return !isValidExpression(expression);
 }
 
 function isValidExpression(expression: string) {

--- a/src/client/flogo/flow/task-configurator/task-configurator.component.ts
+++ b/src/client/flogo/flow/task-configurator/task-configurator.component.ts
@@ -114,6 +114,7 @@ export class TaskConfiguratorComponent implements OnDestroy {
       inputMappings: mappings
     };
   }
+
   onIteratorValueChange(newValue: string) {
     this.tabs.get('iterator').isValid = MapperTranslator.isValidExpression(newValue);
     this.iterableValue = newValue;
@@ -123,14 +124,6 @@ export class TaskConfiguratorComponent implements OnDestroy {
   onChangeIteratorMode() {
     this.iteratorModeOn = !this.iteratorModeOn;
     this.checkIsIteratorDirty();
-  }
-
-  get isValid() {
-    return this.tabs.areDirty();
-  }
-
-  get isDirty() {
-    return this.tabs.areDirty();
   }
 
   save() {


### PR DESCRIPTION
Fixes an issue where save button was disabled if modifying a mapping that was previously of type object mapping but wanted to change to a different type like expression or literal.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
1. Open a task's configuration and add an object mapping like `{ "foo": "{{ $flow.input }}" }`
2. Save
3. Open the same task and change the mapping to `$flow.input`
4. Doesn't report any errors but save button is disabled

**What is the new behavior?**
Removed an unnecessary check that was preventing the save button to enable.
