### PR TITLE
Ensure imported triggers have names.

### DIFF
--- a/src/server/modules/importer/common/abstract-trigger-handlers-importer.js
+++ b/src/server/modules/importer/common/abstract-trigger-handlers-importer.js
@@ -35,7 +35,8 @@ export class AbstractTriggersHandlersImporter {
 
   async importAll(rawApp) {
     const rawTriggers = this.extractTriggers(rawApp);
-    const reconciledTriggers = this.reconcileTriggersAndActions(rawTriggers);
+    const triggers = this.ensureTriggersHaveNames(rawTriggers);
+    const reconciledTriggers = this.reconcileTriggersAndActions(triggers);
     await this.storeTriggersAndHandlers(reconciledTriggers);
   }
 
@@ -71,6 +72,13 @@ export class AbstractTriggersHandlersImporter {
       handler,
       actionId: linkedAction ? linkedAction.id : null,
     };
+  }
+
+  ensureTriggersHaveNames(triggers = []) {
+    return triggers.map(trigger => ({
+      ...trigger,
+      name: trigger.name || trigger.id,
+    }));
   }
 
   /**

--- a/src/server/modules/importer/standard/standard-triggers-handlers-importer.js
+++ b/src/server/modules/importer/standard/standard-triggers-handlers-importer.js
@@ -4,11 +4,7 @@ import { convertMappingsCollection, parseResourceIdFromResourceUri } from './uti
 export class StandardTriggersHandlersImporter extends AbstractTriggersHandlersImporter {
 
   extractTriggers(rawApp) {
-    const standardTriggers = rawApp.triggers || [];
-    return standardTriggers.map(stdTrigger => ({
-      ...stdTrigger,
-      name: stdTrigger.name || stdTrigger.id,
-    }));
+    return rawApp.triggers || [];
   }
 
   extractHandlers(trigger) {


### PR DESCRIPTION
Fixes an issue where legacy app was not importable if trigger name is not provided in the flogo.json but trigger name is not required by the engine.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Importing this app will fail:

```js

{
  "name": "lambda",
  "type": "flogo:app",
  "version": "0.0.1",
  "description": "My flogo application description",
  "triggers": [
    {
      "id": "my_lambda_trigger",
      "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/lambda",
      "settings": {
      },
      "handlers": [
        {
          "actionId": "my_simple_flow",
          "settings": {
          }
        }
      ]
    }
  ],
  "actions": [
    {
      "id": "my_simple_flow",
      "name": "my simple flow",
      "ref": "github.com/TIBCOSoftware/flogo-contrib/action/flow",
      "data": {
        "flow": {
          "name": "my simple flow",
          "attributes": [],
          "rootTask": {
            "id": 1,
            "type": 1,
            "tasks": [
              {
                "id": 2,
                "type": 1,
                "activityRef": "github.com/TIBCOSoftware/flogo-contrib/activity/log",
                "name": "log",
                "attributes": [
                  {
                    "name": "message",
                    "value": "Simple Log",
                    "type": "string"
                  }
                ]
              }
            ],
            "links": [
            ]
          }
        }
      }
    }
  ]
}
```