### PR TITLE
Fixes unable to add tasks to legacy application

### DIFF
--- a/src/client/flogo/flow/shared/diagram/models/flow.model.ts
+++ b/src/client/flogo/flow/shared/diagram/models/flow.model.ts
@@ -63,8 +63,8 @@ export function flogoFlowToJSON(inFlow: UiFlow): LegacyFlowWrapper {
   const flowPathNodes = flowPath.nodes;
   const errorPathRoot = errorPath.rootId;
   const errorPathNodes = errorPath.nodes;
-  const isFlowPath = isEmpty(flowPath) || isEmpty(flowPathRoot) || isEmpty(flowPathNodes);
-  const isErrorPath = isEmpty(errorPath) || isEmpty(errorPathRoot) || isEmpty(errorPathNodes);
+  const isMainFlowEmpty = isEmpty(flowPath) || !flowPathRoot || isEmpty(flowPathNodes);
+  const isErrorFlowEmpty = isEmpty(errorPath) || !errorPathRoot || isEmpty(errorPathNodes);
 
   flowJSON.id = flowID;
   flowJSON.name = inFlow.name || '';
@@ -96,7 +96,7 @@ export function flogoFlowToJSON(inFlow: UiFlow): LegacyFlowWrapper {
     return flowMetadata;
   }
 
-  if (isFlowPath && isErrorPath) {
+  if (isMainFlowEmpty && isErrorFlowEmpty) {
     /* tslint:disable-next-line:no-unused-expression */
     DEBUG && console.warn('Invalid path information in the given flow');
     /* tslint:disable-next-line:no-unused-expression */
@@ -306,7 +306,7 @@ export function flogoFlowToJSON(inFlow: UiFlow): LegacyFlowWrapper {
       return false;
     }
 
-    if (isEmpty(task.id)) {
+    if (!task.id) {
       /* tslint:disable-next-line:no-unused-expression */
       DEBUG && console.warn('Empty task id');
       /* tslint:disable-next-line:no-unused-expression */


### PR DESCRIPTION
Fixes #790

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#790 Unable to add tasks to legacy application

**What is the new behavior?**
Updated the UI transformation check to not use `isEmpty` function for verifying task ids. This problem was most likely introduced when we simplified the diagram model to have a single id for both graph node and task. In the old implementation it was assumed that node ids could only be strings but after the unification they could be either number (legacy actions) or strings. For a number `isEmpty()` returns true.


