### PR TITLE
Fix autocomplete control for triggers wont's show scroll options

### DIFF
--- a/src/client/assets/main.less
+++ b/src/client/assets/main.less
@@ -1016,3 +1016,8 @@ code {
     }
   }
 }
+
+
+.overlay-flex {
+  display: flex;
+}

--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/auto-complete/auto-complete-content.component.html
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/auto-complete/auto-complete-content.component.html
@@ -2,7 +2,7 @@
      class="help"
      [innerHTML]="'TRIGGER-CONFIGURATOR:SETTINGS:AUTOCOMPLETE-HELP' | translate">
 </div>
-<div class="all-options-wrapper">
+<div class="all-options-wrapper" *ngIf="(options?.allowedValues | async)?.length > 0 || (options?.appVariables | async)?.length > 0">
     <ng-container *ngIf="options?.allowedValues | async as allowedValues">
       <ul role="listbox" *ngIf="allowedValues.length > 0" class="options-group">
         <li *ngFor="let value of allowedValues"

--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/auto-complete/auto-complete-content.component.less
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/auto-complete/auto-complete-content.component.less
@@ -8,7 +8,7 @@
   position: relative;
   margin-top: 6px;
   margin-bottom: 6px;
-  max-height: 436px;
+  width: 100%;
 }
 
 .help {
@@ -25,6 +25,7 @@
 .all-options-wrapper {
   flex: 1;
   overflow: auto;
+  min-height: 62px;
 }
 
 .options-group {


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The control for the trigger settings autocomplete is positioned depending on its contents when it is first opened. After filtering if the number of results is greater than the results when first rendered the scrollbars are not displayed and the content overflows the screen making it impossible to access all the results.

**What is the new behavior?**
Autocomplete is positioned depending on the available space in the viewport, based on the minimum height required for the control to be rendered.