### PR TITLE
Styling of help menu content to make them consistent with the others

### DIFF
--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/settings/help/help.component.less
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/settings/help/help.component.less
@@ -33,6 +33,7 @@
       a {
         .uxpl-dropdown__item;
         display: block;
+        text-decoration: none;
       }
     }
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently the help menu content and it's items are not consistent with the rest of the application.


**What is the new behavior?**
Changes made to use the dropdown menu style mixins to style the help content. Also added a `:after` element to the help content to fill the empty gap between the icon and the menu (which is toggling the hover state to off while moving the cursor towards the menu item)