### PR TITLE
[839] - Reset the isDirty state of individual input properties

### DIFF
--- a/src/client/flogo/flow/shared/mapper/services/mapper-controller/mapper-controller.ts
+++ b/src/client/flogo/flow/shared/mapper/services/mapper-controller/mapper-controller.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import { forIn, cloneDeep } from 'lodash';
 import { ReplaySubject ,  Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -95,7 +95,11 @@ export class MapperController {
   }
 
   resetStatus() {
-    this.updateState({ ...this.getCurrentState(), isDirty: false });
+    const resetState: MapperState = { ...this.getCurrentState(), isDirty: false };
+    forIn(resetState.inputs.nodes, node => {
+      node.isDirty = false;
+    });
+    this.updateState(resetState);
   }
 
   getCurrentState() {

--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/trigger-detail.component.ts
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/trigger-detail.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import {FormGroup} from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { filter, shareReplay, switchMap, take, takeUntil } from 'rxjs/operators';
+import { filter, switchMap, take, takeUntil } from 'rxjs/operators';
 
 import { SingleEmissionSubject } from '@flogo/core/models/single-emission-subject';
 import { MapperController } from '@flogo/flow/shared/mapper/services/mapper-controller/mapper-controller';
@@ -53,10 +53,7 @@ export class TriggerDetailComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.overallStatus$ = this.store.pipe(
-      TriggerConfigureSelectors.getCurrentTriggerOverallStatus,
-      shareReplay(),
-    );
+    this.overallStatus$ = this.store.pipe(TriggerConfigureSelectors.getCurrentTriggerOverallStatus);
 
     this.tabs$ = this.store.pipe(TriggerConfigureSelectors.getCurrentTabs);
     this.store


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When we save the trigger configuration, we are resetting the state of the `isDirty` of the whole `input mappings` and `reply mappings`. But the `isDirty` state of each input node is not reset to false. Thus the actions are not enabled again


**What is the new behavior?**
I am now resetting the `isDirty` state of each input nodes to `false`. Also I have removed unnessary `shareReplay` operator usage while building the `overallStatus$` stream.