### PR TITLE
[838] - previousState is updated on every trigger configuration save 

### DIFF
--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/trigger-detail.component.ts
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/trigger-detail.component.ts
@@ -85,14 +85,13 @@ export class TriggerDetailComponent implements OnInit, OnDestroy {
 
   save() {
     const currentTriggerId = this.selectedTriggerId;
+    const isUpdateStillApplicable = () => this.selectedTriggerId !== currentTriggerId || !this.ngDestroy$.closed;
     this.configuratorService.save()
-      .subscribe(() => {
-        const isUpdateStillApplicable = this.selectedTriggerId !== currentTriggerId || !this.ngDestroy$.closed;
-        if (!isUpdateStillApplicable) {
-          return;
-        }
-
-        this.getCurrentTriggerState.subscribe(state => this.previousState = state);
+      .pipe(
+        filter(() => isUpdateStillApplicable()),
+        switchMap(() => this.getCurrentTriggerState)
+      ).subscribe((triggerState) => {
+        this.previousState = triggerState;
         this.settingsForm.reset(this.settingsForm.getRawValue());
         this.updateSettingsStatus({
           // TODO: replace manual valid check when async validation bug is fixed in ng forms -> github.com/angular/angular/issues/20424


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
We load the `previousState` only when the trigger configuration for a trigger is initialized. We need to update the `previousState` every time on saving the trigger configuration 


**What is the new behavior?**
When user saves the trigger configuration we are updating the `previousState` with the latest trigger configure state.