### PR TITLE
[Flogo/342] - Displaying the attribute / setting value always

### DIFF
--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/auto-complete/auto-complete.directive.ts
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/auto-complete/auto-complete.directive.ts
@@ -223,9 +223,10 @@ export class AutoCompleteDirective implements OnChanges, OnInit, OnDestroy {
   }
 
   private optionSelected(option: string) {
-    this.formControl.setValue(option);
     if (this.valueAccessor) {
       this.valueAccessor.update(option);
+    } else {
+      this.formControl.setValue(option);
     }
     this.close();
   }

--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-form-builder.ts
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-form-builder.ts
@@ -1,4 +1,4 @@
-import {isEmpty, isObject, mapValues} from 'lodash';
+import {isEmpty, isString, mapValues, isUndefined, isNull} from 'lodash';
 import {Injectable} from '@angular/core';
 import {Dictionary} from '@flogo/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
@@ -59,8 +59,8 @@ export class SettingsFormBuilder {
   }
 
   private makeFormControl(setting, settingInfo: SettingControlInfo, disableControls?: boolean) {
-    const value = setting.value || '';
-    const viewValue = isObject(value) ? JSON.stringify(value, null, 2) : value;
+    const value = !isNull(setting.value) && !isUndefined(setting.value) ? setting.value : '';
+    const viewValue = isString(value) ? value : JSON.stringify(value, null, 2);
     return this.ngFormBuilder.control({
       value: <SettingValue> {
         viewValue,

--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-validation/required.validator.spec.ts
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-validation/required.validator.spec.ts
@@ -1,0 +1,27 @@
+import {requiredValidator} from './required.validator';
+import {makeExpectationFunctions} from './testing/make-expectation-functions';
+import {SettingValue} from '../settings-value';
+import {isString, isNull} from 'lodash';
+
+describe('requiredValidator', () => {
+  it('Should correctly validate required values', () => {
+    const {shouldPass, shouldFail} = makeExpectationFunctions(requiredValidator);
+    shouldPass(createTestData(0));
+    shouldPass(createTestData(false));
+    shouldPass(createTestData('true'));
+    shouldPass(createTestData(-123));
+    shouldFail(createTestData(undefined));
+    shouldFail(createTestData(null));
+    shouldFail(createTestData(''));
+    shouldFail(createTestData('      '));
+  });
+});
+
+function createTestData(value: any): {value: SettingValue} {
+  return {
+    value: {
+      parsedValue: value,
+      viewValue: isString(value) || isNull(value) ? value : JSON.stringify(value)
+    }
+  };
+}

--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-validation/required.validator.ts
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-validation/required.validator.ts
@@ -1,8 +1,11 @@
-import { AbstractControl } from '@angular/forms';
 import { SettingValue } from '../settings-value';
 import { ErrorTypes } from './error-types';
+import { isUndefined, isNull } from 'lodash';
 
-export function requiredValidator(control: AbstractControl) {
+export function requiredValidator(control: {value: SettingValue}) {
   const value = control.value as SettingValue;
-  return value == null || !value.viewValue ? {[ErrorTypes.Required]: true} : null;
+  if (value == null || isUndefined(value.viewValue) || isNull(value.viewValue) || value.viewValue.trim() === '') {
+    return {[ErrorTypes.Required]: true};
+  }
+  return null;
 }

--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-validation/testing/make-expectation-functions.ts
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-validation/testing/make-expectation-functions.ts
@@ -1,0 +1,4 @@
+export const makeExpectationFunctions = validatorFunction => ({
+  shouldPass: val => expect(validatorFunction(val)).toBeFalsy(`Expected ${val} to pass the validation`),
+  shouldFail: val => expect(validatorFunction(val)).toBeTruthy(`Expected ${val} to NOT pass the validation`)
+});

--- a/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-validation/type.validator.spec.ts
+++ b/src/client/flogo/flow/triggers/configurator/trigger-detail/settings-validation/type.validator.spec.ts
@@ -1,10 +1,6 @@
 import {arrayValidator, booleanValidator, getNumberValidator, getObjectValidator} from './type.validator';
+import {makeExpectationFunctions} from './testing/make-expectation-functions';
 import {ValueType} from '@flogo/core';
-
-const makeExpectationFunctions = validatorFunction => ({
-  shouldPass: val => expect(validatorFunction(val)).toBeFalsy(`Expected ${val} to pass the validation`),
-  shouldFail: val => expect(validatorFunction(val)).toBeTruthy(`Expected ${val} to NOT pass the validation`)
-});
 
 describe('booleanValidator', function () {
   it('Should correctly validate boolean values', function () {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
1. When we save the value of a trigger setting or handler setting of type boolean with false and save, the value disappears the next time when I launch the trigger configuration details.

2. The `SettingValue.viewValue` contains a type specific to it's setting definition in the schema even though it's interface definition says that it is a `string` type.

3. Selecting a value from the auto complete makes the `value` in `requiredValidator` function as `string` type instead of `SettingValue` type.

4. Empty spaces in the required field is considered as valid

5. If my property is of type `integer` / `double`, having a value `0` fails the required validation 

**What is the new behavior?**
1. Fixes TIBCOSoftware/flogo#342, The value appears for certain cases

2. The `SettingValue.viewValue` always maintains it as string type

3. Selecting a value from the auto complete makes the `value` in `requiredValidator` function as of type `SettingValue` type, keeping it consistent with all other cases

4. Implemented required validation for empty spaces string `      `

5. For `integer` / `double` type properties, the value `0` is valid