### PR TITLE
[export/legacy] An attribute's schema details is exposed in the application JSON

### DIFF
--- a/src/server/modules/apps/schemas/full-app-schema.json
+++ b/src/server/modules/apps/schemas/full-app-schema.json
@@ -243,6 +243,7 @@
         "attribute": {
           "title": "attribute",
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string"


### PR DESCRIPTION
While exporting an application JSON in legacy format, the attribute definitions of a task contains the properties like `required`, `allowed` etc which are schema based properties. The task attribute definition only needs to care for `name`, `value` and `type` of the task attribute.

Bug: 
```
{
  ...
  ...
  "actions": [
    {
      ...
      ...
      "data": {
        "flow": {
          ...
          "rootTask": {
            ...
            "tasks": [
              {
                ...
                "attributes": [
                  ....
                  {
                    "name": "method",
                    "type": "string",
                    "required": true,  --> Schema details not to be available here
                    "allowed": [  --> Schema details not to be available here
                      "GET",
                      "POST",
                      "PUT",
                      "PATCH",
                      "DELETE"
                    ],
                    "value": "GET"
                  }
                ],
                ....
}
```

Fix: 
```
{
  ...
  ...
  "actions": [
    {
      ...
      ...
      "data": {
        "flow": {
          ...
          "rootTask": {
            ...
            "tasks": [
              {
                ...
                "attributes": [
                  ....
                  {
                    "name": "method",
                    "type": "string",
                    "value": "GET"
                  }
                ],
                ...
```