### PR TITLE
Fix debugger selection was not cleared out.

### DIFF
--- a/src/client/flogo/flow/debug-panel/debug-activity-task.spec.ts
+++ b/src/client/flogo/flow/debug-panel/debug-activity-task.spec.ts
@@ -1,0 +1,38 @@
+import { of } from 'rxjs';
+import { combineToDebugActivity, DebugActivityTask } from './debug-activity-task';
+
+describe('debug-panel.debug-activity-task.combineToDebugActivity', function () {
+
+  const emitAndCombine = (emitValues) => of(emitValues)
+    .pipe(combineToDebugActivity())
+    .toPromise();
+
+  it('A merged debug activity tasks', async () => {
+    const result = await emitAndCombine([
+        { id: 'my-schema', name: 'my-schema', homepage: 'https://my.activity.homepage.com' },
+        { id: 'activity1', name: 'my activity', return: true, },
+      ]);
+    expect<Partial<DebugActivityTask>>(result).toEqual({
+      id: 'activity1',
+      name: 'my activity',
+      return: true,
+      schemaHomepage: 'https://my.activity.homepage.com',
+    });
+  });
+
+  it('Returns null when both streams are empty', async () => {
+    const result = await emitAndCombine([null, null]);
+    expect(result).toBeFalsy();
+  });
+
+  it('Returns null when activity schema is empty', async () => {
+    const result = await emitAndCombine([null, { id: 'activity1', name: 'my activity' }]);
+    expect(result).toBeFalsy();
+  });
+
+  it('Returns null when activity task is empty', async () => {
+    const result = await emitAndCombine([{ id: 'my-schema', name: 'my-schema', homepage: 'https://my.activity.homepage.com' },  null]);
+    expect(result).toBeFalsy();
+  });
+
+});

--- a/src/client/flogo/flow/debug-panel/debug-activity-task.ts
+++ b/src/client/flogo/flow/debug-panel/debug-activity-task.ts
@@ -1,5 +1,13 @@
-import {ItemActivityTask} from '@flogo/core';
+import { Observable, OperatorFunction } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ItemActivityTask, ActivitySchema } from '@flogo/core';
 
 export interface DebugActivityTask extends ItemActivityTask {
   schemaHomepage: string;
+}
+
+export function combineToDebugActivity(): OperatorFunction<[ActivitySchema, ItemActivityTask], DebugActivityTask> {
+  return (source: Observable<[ActivitySchema, ItemActivityTask]>) => source.pipe(
+    map(([schema, activity]) => activity && schema ? {...activity, schemaHomepage: schema.homepage} : null),
+  );
 }

--- a/src/client/flogo/flow/debug-panel/debug-panel.component.ts
+++ b/src/client/flogo/flow/debug-panel/debug-panel.component.ts
@@ -16,7 +16,7 @@ import { FormBuilderService } from '@flogo/flow/shared/dynamic-form';
 import { debugPanelAnimations } from './debug-panel.animations';
 import { mergeFormWithOutputs } from './utils';
 import { FieldsInfo } from './fields-info';
-import { DebugActivityTask } from './debug-activity-task';
+import { DebugActivityTask, combineToDebugActivity } from './debug-activity-task';
 import { isMapperActivity } from '@flogo/shared/utils';
 
 const SELECTOR_FOR_CURRENT_ELEMENT = 'flogo-diagram-tile-task.is-selected';
@@ -72,7 +72,8 @@ export class DebugPanelComponent implements OnInit, OnDestroy {
 
     const schema$ = selectAndShare(FlowSelectors.getSelectedActivitySchema);
     const selectedActivity$ = selectAndShare(FlowSelectors.getSelectedActivity);
-    this.activity$ = combineLatest(schema$, selectedActivity$).pipe(this.prepareDebugActivity(), shareReplay(1));
+    this.activity$ = combineLatest(schema$, selectedActivity$)
+      .pipe(combineToDebugActivity(), shareReplay(1));
     this.flowHasRun$ = selectAndShare(FlowSelectors.getFlowHasRun);
     this.isEndOfFlow$ = schema$.pipe(map(isMapperActivity));
     const form$: Observable<null | FieldsInfo> = schema$.pipe(this.mapStateToForm(), shareReplay(1));
@@ -128,13 +129,6 @@ export class DebugPanelComponent implements OnInit, OnDestroy {
 
   get isOpen(): boolean {
     return this.panelStatus === STATUS_OPEN;
-  }
-
-  private prepareDebugActivity() {
-    return (source: Observable<[ActivitySchema, ItemActivityTask]>) => source.pipe(
-      filter(([schema]) => !!schema),
-      map(([schema, activity]) => ({...activity, schemaHomepage: schema.homepage}))
-    );
   }
 
   private changePanelState(isOpen: boolean) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When selecting an activity we can see its info in the debugger (this is correct), then selecting the error handler clears the selection in the diagram but still displays the prev activity's info in the debugger but with empty fields.

![problem](https://user-images.githubusercontent.com/17577698/47825448-33f9a400-dd2f-11e8-8b28-9eebed1ffb8f.gif)



**What is the new behavior?**

It correctly clears the selection from the debug panel.

![solution](https://user-images.githubusercontent.com/17577698/47825469-58558080-dd2f-11e8-8a46-8e15d869cd98.gif)



**Other information**:
Filter operator was preventing the stream to emit and thus preventing to clear the current activity in the debugger.