### PR TITLE
part of 719 - Alignment and scaling changes for tiles and branches

### DIFF
--- a/src/client/flogo/packages/diagram/renderable-model/create-tile-matrix.ts
+++ b/src/client/flogo/packages/diagram/renderable-model/create-tile-matrix.ts
@@ -4,7 +4,7 @@ import {TaskTile, Tile} from '../interfaces/tile';
 
 import {NodeMatrix, TileMatrix} from './matrix';
 import {tileFactory} from './tile-factory';
-import {NodeType} from '@flogo/core';
+import {GraphNodeDictionary, NodeType} from '@flogo/core';
 
 const TILE_PADDING = tileFactory.makePadding();
 const TILE_PLACEHOLDER = tileFactory.makePlaceholder();
@@ -12,7 +12,7 @@ const fillWithPlaceholders = (fromCount: number, max: number) => times(max - fro
 
 // assumes that the rows won't overflow
 // and the overflow case should be handled somewhere else.
-export function createTileMatrix(nodeMatrix: NodeMatrix, nodes, maxRowLength, isReadOnly = false): TileMatrix {
+export function createTileMatrix(nodeMatrix: NodeMatrix, nodes: GraphNodeDictionary, maxRowLength, isReadOnly = false): TileMatrix {
   const maxTileIndex = maxRowLength - 1;
   const nodeToTile = (node, index) => !!node ? tileFactory.makeTask(node, index >= maxTileIndex) : TILE_PADDING;
   return nodeMatrix.map(rowOfNodes => {

--- a/src/client/flogo/packages/diagram/tiles/tile-branch.component.less
+++ b/src/client/flogo/packages/diagram/tiles/tile-branch.component.less
@@ -12,6 +12,13 @@
     background-color: #79b8dc;
     border: none;
   }
+  .main-branch-link {
+    border-top: solid 4px #79b8dc;
+    &::after {
+      background-color: #79b8dc;
+      border: solid 2px #79b8dc;
+    }
+  }
   .menu-icon-close {
     color: @color-bg;
   }

--- a/src/client/flogo/packages/diagram/tiles/tile-task.component.html
+++ b/src/client/flogo/packages/diagram/tiles/tile-task.component.html
@@ -12,10 +12,11 @@
     <ng-template #returnActivityIcon>
       <img class=" content__icon content__icon-return" src="/assets/svg/flogo-return-activity.svg" alt="Return">
     </ng-template>
-    <div class="content__text" [ngClass] = "tile.task?.features?.subflow ? 'content__text--subflow' : 'content__text--title'">
+    <div class="content__text content__text--title"
+         [ngClass]="{'content__text--subflow' : tile.task?.features?.subflow, 'content__text--return': isTerminal }">
       {{ tile.task.title }}
     </div>
-    <div class="content__text content__text--id" *ngIf="!tile.task?.features?.subflow">
+    <div class="content__text content__text--id" *ngIf="!tile.task?.features?.subflow && !isTerminal">
       {{ tile.task.id }}
     </div>
   </div>

--- a/src/client/flogo/packages/diagram/tiles/tile-task.component.less
+++ b/src/client/flogo/packages/diagram/tiles/tile-task.component.less
@@ -12,8 +12,7 @@
   font-size: 12px;
 
   &:hover {
-    transform: scale(1.08) translate(6%, 0%);
-    z-index: 2;
+    transform: scale(1.04);
   }
 }
 
@@ -55,6 +54,10 @@
   height: 24px;
   background-color: #36bfbb;
   border-radius: 4px;
+}
+
+.content__text--return {
+  margin-top: 5px;
 }
 
 .content__icon-subflow {
@@ -196,13 +199,16 @@
   margin-left: -7px;
   margin-right: 6px;
   &:hover {
-    z-index: 2;
-    transform: scale(1.08) translate(-7%, 0);
+    transform: scale(1.04) translate(-3%, 0);
   }
 }
 
+:host(.tile-has-branch.is-selected) {
+  transform: scale(1.04) translate(-3%, 0);
+}
+
 :host(.is-selected) {
-  transform: scale(1.08) translate(6%, 0%);
+  transform: scale(1.04);
   .tile__bg {
     fill: @color-link-hover;
   }

--- a/src/client/flogo/packages/diagram/tiles/tile-task.component.ts
+++ b/src/client/flogo/packages/diagram/tiles/tile-task.component.ts
@@ -11,10 +11,10 @@ import {animate, style, transition, trigger} from '@angular/animations';
   animations: [  trigger('menuOptions', [
     transition('void => *', [
       style({opacity: 0}),
-      animate('250ms ease-in')
+      animate('100ms ease-in')
     ]),
     transition('* => void', [
-      animate('250ms ease-in', style({ opacity: 0}))
+      animate('100ms ease-in', style({ opacity: 0}))
     ]),
   ])]
 })


### PR DESCRIPTION
part of #719 
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
Includes below changes :
1. Decrease menu open/close animation to 100ms.
2. Decrease "grow" effect to 4% - scale(1.04) - make sure overlapping is not happening, branches are always on top.
3. Missing state for main branch. Main branch should change colors when ran.
4. Implementation of design for return tile.
5. Branch should stay on top of tile when hovering and it also should be clickable.
6. Hover/selected tile should grow from the center, growing to the left is only for activities with branches.


**Other information**:
