### PR TITLE
[906] - Removed "Trigger not installed" error as default

### DIFF
--- a/src/client/flogo/home/apps-list/apps-list.component.ts
+++ b/src/client/flogo/home/apps-list/apps-list.component.ts
@@ -75,12 +75,10 @@ export class FlogoAppsListComponent implements OnInit {
       key = 'APP-LIST:BROKEN_RULE_WRONG_INPUT_JSON_FILE';
     } else {
       if (error[0].status === 400) {
-        if (error[0].meta.details) {
+        if (error[0].meta && error[0].meta.details) {
           this.importValidationErrors = error[0].meta.details;
           this.showValidationErrors = true;
           key = 'APP-LIST:VALIDATION_ERROR';
-        } else {
-          key = 'APP-LIST:BROKEN_RULE_NOT_INSTALLED_TRIGGER';
         }
       } else if (error.status === 500) {
         key = 'APP-LIST:INTERNAL_ERROR';

--- a/src/client/i18n/en.json
+++ b/src/client/i18n/en.json
@@ -20,8 +20,6 @@
   "APP-LIST:VALIDATION_ERROR": "Encountered validation errors",
   "APP-LIST:INTERNAL_ERROR": "Internal error",
   "APP-LIST:BROKEN_RULE_UNKNOWN": "Unknown error",
-  "APP-LIST:BROKEN_RULE_NOT_INSTALLED_ACTIVITY": "Activity is not installed",
-  "APP-LIST:BROKEN_RULE_NOT_INSTALLED_TRIGGER": "Trigger is not installed",
   "APP": {
     "MISSING_TRIGGER": {
       "TITLE": "Some flows don’t have triggers yet.",


### PR DESCRIPTION
Fixes #906 
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently the error message while importing an application is default to the message `Trigger is not installed` while it is originally occurred due to a different issue.

**What is the new behavior?**
The default unhandled error message is restored to `Unknown error`