### PR TITLE
Fix row background doesn't extend to the end of its parent.

### DIFF
--- a/src/client/flogo/flow/flow-diagram/flow-diagram.component.ts
+++ b/src/client/flogo/flow/flow-diagram/flow-diagram.component.ts
@@ -14,6 +14,10 @@ import {FlowGraph} from '@flogo/core';
 @Component({
   selector: 'flogo-flow-diagram',
   templateUrl: 'flow-diagram.component.html',
+  styles: [`
+    :host { display: flex; }
+    flogo-diagram { flex: 1; }
+  `],
 })
 
 export class FlogoFlowDiagramComponent {

--- a/src/client/flogo/flow/flow.component.less
+++ b/src/client/flogo/flow/flow.component.less
@@ -38,6 +38,8 @@
 
 .diagram {
   flex: 1;
+  display: inline-flex;
+  align-items: flex-start;
   background-color: @gainsboro-nine;
 }
 

--- a/src/client/flogo/packages/diagram/diagram/diagram.component.less
+++ b/src/client/flogo/packages/diagram/diagram/diagram.component.less
@@ -3,7 +3,6 @@
   flex-direction: column-reverse;
   position: relative;
   z-index: 0;
-  align-items: flex-start;
 }
 
 .diagram-row {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Issue with row background:

![screen shot 2018-11-12 at 2 17 15 pm](https://user-images.githubusercontent.com/17577698/48378531-c4b47600-e685-11e8-9248-233335b054ec.png)


![screen shot 2018-11-12 at 2 17 20 pm](https://user-images.githubusercontent.com/17577698/48378526-c120ef00-e685-11e8-9c8b-875143219eca.png)



**What is the new behavior?**

![screen shot 2018-11-12 at 2 16 32 pm](https://user-images.githubusercontent.com/17577698/48378543-cf6f0b00-e685-11e8-8fcb-822b92b6d526.png)

![screen shot 2018-11-12 at 2 16 47 pm](https://user-images.githubusercontent.com/17577698/48378549-d4cc5580-e685-11e8-8d33-04a0acb019b5.png)


