### PR TITLE
Alignment issue with task's menu options

### DIFF
--- a/src/client/flogo/packages/diagram/tiles/tile-task.component.less
+++ b/src/client/flogo/packages/diagram/tiles/tile-task.component.less
@@ -95,6 +95,10 @@
   display: flex;
 }
 
+.menu-options {
+  display: flex;
+}
+
 .menu__icon {
   padding: 2px 4px;
   margin-left: 5px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The latest tile designs have an alignment issue with the tile's menu options in Edge browser. Below are the screenshots:
Normal:
<img src="https://user-images.githubusercontent.com/23206463/49213562-8db2c400-f3ea-11e8-876d-d367b9fa64f3.png" height="160px" width="200px" />

<img src="https://user-images.githubusercontent.com/23206463/49213570-92777800-f3ea-11e8-8624-97b058e2798a.png" height="150px" width="200px" />

**What is the new behavior?**
The task's menu aligns accordingly in Edge and no effect in Chrome and firefox:
<img src="https://user-images.githubusercontent.com/23206463/49214223-2990ff80-f3ec-11e8-9845-dd45c8002f4e.png" height="140px" width="200px" />

<img src="https://user-images.githubusercontent.com/23206463/49214235-31e93a80-f3ec-11e8-9db5-3fbe8e4abb70.png" height="140px" width="200px" />