### PR TITLE
[977] Display condition value in branch configurator

### DIFF
--- a/libs/plugins/flow-client/src/lib/branch-configurator/branch-configurator-context.ts
+++ b/libs/plugins/flow-client/src/lib/branch-configurator/branch-configurator-context.ts
@@ -1,26 +1,19 @@
 import { ValueType } from '@flogo-web/client-core';
+import { EXPR_PREFIX } from '@flogo-web/core';
 
 export const CONDITION_KEY = 'condition';
 
 export function createBranchMappingContext(
   condition: string
-): { propsToMap: any[]; mappings: any[] } {
-  let propsToMap = [];
-  let mappings = [];
-  propsToMap = [
+): { propsToMap: any[]; mappings: any } {
+  const propsToMap = [
     {
       name: CONDITION_KEY,
       type: ValueType.Boolean,
     },
   ];
-
-  mappings = [
-    {
-      type: ValueType.Boolean,
-      mapTo: CONDITION_KEY,
-      value: condition,
-    },
-  ];
+  const mappings = {};
+  mappings[CONDITION_KEY] = EXPR_PREFIX + condition;
 
   return { mappings, propsToMap };
 }


### PR DESCRIPTION
Fixes #977 
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The branch conditions are not displayed in the branch configurator

**What is the new behavior?**
The condition is displayed in the configurator. Changed the branch context creator such that it adapts to the latest changes to MapperTranslator's `translateMappingsIn` function