### PR TITLE
fix(plugins-flow-server): exporting mapper activity

### DIFF
--- a/libs/plugins/flow-server/src/lib/export/task-formatter.ts
+++ b/libs/plugins/flow-server/src/lib/export/task-formatter.ts
@@ -3,7 +3,6 @@ import { isEmpty } from 'lodash';
 import { Task, createResourceUri, Resource } from '@flogo-web/core';
 import { isSubflowTask, TASK_TYPE } from '@flogo-web/server/core';
 import { isIterableTask } from '@flogo-web/plugins/flow-core';
-import { Dictionary } from '@flogo-web/client-core';
 
 export class TaskFormatter {
   private sourceTask: Task;
@@ -43,7 +42,7 @@ export class TaskFormatter {
     } = {};
     const activitySettings: {
       flowURI?: string;
-      mappings?: Dictionary<any>;
+      mappings?: { [flowOutput: string]: any };
     } = {};
     // for type 'standard' we will omit the 'type' property as a task is 'standard' by default
     let type;


### PR DESCRIPTION
Mapper type of tasks adding "mappings" to "input" property instead of "settings"

fixes #1020

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Mapper type of tasks adding "mappings" to "input" property instead of "settings"


**What is the new behavior?**
In the exported JSON, mapper type of tasks will have "mappings" property in "input" field.


