### PR TITLE
fix(parser): single quotes in json should not be accepted by parser

### DIFF
--- a/libs/parser/src/ast/ast-creator.ts
+++ b/libs/parser/src/ast/ast-creator.ts
@@ -220,7 +220,7 @@ export function astCreatorFactory(BaseCstVisitorClass: CstVisitorBase): CstVisit
     }
 
     objectItem(ctx): JsonNodes.PropertyNode {
-      const key = JSON.parse(ctx.StringLiteral[0].image);
+      const key = JSON.parse(ctx.DblQuoteStringLiteral[0].image);
       const value = <JsonNodes.ValueNode>this.visit(ctx.jsonValue);
       return {
         type: 'jsonProperty',

--- a/libs/parser/src/parse.spec.ts
+++ b/libs/parser/src/parse.spec.ts
@@ -1,5 +1,6 @@
 import { LiteralNode, PropertyNode, StringTemplateNode } from './ast';
 import { parse, parseResolver } from './parse';
+import './tests/jest-matchers';
 
 describe('parse', function() {
   it('parses simple resolvers', function() {
@@ -101,28 +102,39 @@ describe('parse', function() {
 
   it('parses ternary expressions', function() {
     const parseResult = parse('a > b ? true : false');
-    expect(parseResult.ast).toBeTruthy();
-    expect(parseResult.lexErrors.length).toBeFalsy();
-    expect(parseResult.parseErrors.length).toBeFalsy();
-    expect(parseResult.ast.type).toEqual('ExprStmt');
-    expect(parseResult.ast['x'].type).toEqual('TernaryExpr');
+    expect(parseResult).toHaveBeenSuccessfullyParsed();
+    expect(parseResult).toBeExpressionOfType('TernaryExpr');
   });
 
   it('parses expressions with parenthesis', function() {
     const parseResult = parse('(true)');
-    expect(parseResult.ast).toBeTruthy();
-    expect(parseResult.lexErrors.length).toBeFalsy();
-    expect(parseResult.parseErrors.length).toBeFalsy();
-    expect(parseResult.ast.type).toEqual('ExprStmt');
-    expect(parseResult.ast['x'].type).toEqual('ParenExpr');
+    expect(parseResult).toHaveBeenSuccessfullyParsed();
+    expect(parseResult).toBeExpressionOfType('ParenExpr');
   });
 
   it('parses expressions with parenthesis', function() {
     const parseResult = parse('(a + 2) * 55');
-    expect(parseResult.ast).toBeTruthy();
-    expect(parseResult.lexErrors.length).toBeFalsy();
-    expect(parseResult.parseErrors.length).toBeFalsy();
-    expect(parseResult.ast.type).toEqual('ExprStmt');
-    expect(parseResult.ast['x'].type).toEqual('BinaryExpr');
+    expect(parseResult).toHaveBeenSuccessfullyParsed();
+    expect(parseResult).toBeExpressionOfType('BinaryExpr');
+  });
+
+  describe('it handles json values', () => {
+    it('for well formed json', () => {
+      const parseResult = parse(`{
+         "aString": "abcd",
+         "anInteger": 2345,
+         "aDouble": 78.91,
+         "aBoolean": false,
+         "anObject": { "foo": { "bar": true } },
+         "anArray": [ 1, { "foo": "bar" }, true ]
+      }`);
+      expect(parseResult).toHaveBeenSuccessfullyParsed();
+      expect(parseResult.ast.type).toEqual('json');
+    });
+
+    it('does not take single quoted strings', () => {
+      expect(parse(`{ 'a': "b" }`)).not.toHaveBeenSuccessfullyParsed();
+      expect(parse(`{ "a": 'b' }`)).not.toHaveBeenSuccessfullyParsed();
+    });
   });
 });

--- a/libs/parser/src/parser/parser.ts
+++ b/libs/parser/src/parser/parser.ts
@@ -547,7 +547,7 @@ export class MappingParser extends Parser {
   });
 
   protected objectItem = this.RULE('objectItem', () => {
-    this.CONSUME(Token.StringLiteral);
+    this.CONSUME(Token.DblQuoteStringLiteral);
     this.CONSUME(Token.Colon);
     this.SUBRULE(this.jsonValue);
   });

--- a/libs/parser/src/tests/jest-matchers.ts
+++ b/libs/parser/src/tests/jest-matchers.ts
@@ -1,0 +1,76 @@
+import 'jest';
+import { ParseResult } from '../parser/parse-result';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveBeenSuccessfullyParsed();
+      toBeExpressionOfType(type: string);
+    }
+  }
+}
+
+const fail = message => ({ message, pass: false });
+
+expect.extend({
+  toBeExpressionOfType(parseResult: ParseResult, expectedType: string) {
+    if (!parseResult) {
+      return fail(() => `Expected a ParseResult but got ${parseResult}`);
+    } else if (!parseResult.ast) {
+      return fail(() => `No .ast property found in recieved parse result`);
+    }
+    const ast = parseResult.ast;
+
+    if (ast.type !== 'ExprStmt') {
+      return fail(
+        () => `Expected an expression statement (ExprStmt) but got ${ast.type}`
+      );
+    }
+
+    const typeOfChildExpression = ast['x'] ? ast['x'].type : undefined;
+    if (typeOfChildExpression !== expectedType) {
+      return fail(
+        () =>
+          `Expected child expression to be "${expectedType}" but got "${typeOfChildExpression}`
+      );
+    }
+
+    return {
+      pass: true,
+      message: `Recieved expected parse result of expression statement of type ${expectedType}`,
+    };
+  },
+  toHaveBeenSuccessfullyParsed(parseResult: ParseResult, expectedType: string) {
+    if (!parseResult) {
+      return fail(() => `Expected a ParseResult but got ${parseResult}`);
+    }
+
+    const errors = [];
+
+    if (!parseResult.ast && !this.isNot) {
+      errors.push('Expecting parse result to have an .ast property but none found');
+    }
+
+    if (parseResult.lexErrors && parseResult.lexErrors.length > 0) {
+      errors.push(
+        `Expecting 0 lexing errors but found ${parseResult.lexErrors.length}: \n` +
+          this.utils.printReceived(parseResult.lexErrors)
+      );
+    }
+
+    if (parseResult.parseErrors && parseResult.parseErrors.length > 0) {
+      errors.push(
+        `Expecting 0 parse errors but found ${parseResult.parseErrors.length}: \n` +
+          this.utils.printReceived(parseResult.parseErrors)
+      );
+    }
+
+    const hasErrors = errors.length > 0;
+    return {
+      pass: !hasErrors,
+      message: hasErrors
+        ? () => errors.join('. ')
+        : () => 'No errors found in parse result',
+    };
+  },
+});

--- a/libs/parser/tsconfig.lib.json
+++ b/libs/parser/tsconfig.lib.json
@@ -22,5 +22,5 @@
     "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
-  "exclude": ["src/test.ts", "**/*.spec.ts"]
+  "exclude": ["src/test.ts",  "**/tests/*", "**/*.spec.ts"]
 }

--- a/libs/parser/tsconfig.spec.json
+++ b/libs/parser/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/libs/parser",
-    "types": ["jasmine", "node"]
+    "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts",  "**/tests/*", "**/*.d.ts"]
 }

--- a/libs/server/core/tsconfig.lib.json
+++ b/libs/server/core/tsconfig.lib.json
@@ -28,6 +28,7 @@
   },
   "exclude": [
     "src/test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "**/tests/*"
   ]
 }

--- a/libs/server/core/tsconfig.spec.json
+++ b/libs/server/core/tsconfig.spec.json
@@ -11,6 +11,5 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true
   },
-  
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts",  "**/tests/*", "**/*.d.ts"]
 }


### PR DESCRIPTION
Lexer now won't recognize single quoted strings in json.

fixes #1026

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

fixes #1026


**What is the new behavior?**

Parser doesn't accept single quoted strings when parsing a JSON object, AST creator will only accept double quoted string literals.

**Other information**:
