### PR TITLE
fix(server): handler's action property should not persist after import

### DIFF
--- a/apps/server/src/modules/transfer/common/normalize-handler-mappings.spec.ts
+++ b/apps/server/src/modules/transfer/common/normalize-handler-mappings.spec.ts
@@ -12,8 +12,8 @@ describe('importer.common.normalize-handler-mappings', () => {
       { mappings: { output: [] } },
       { input: null },
       { output: null },
-      { input: [] },
-      { output: [] },
+      { input: {} },
+      { output: {} },
     ];
     testCases.forEach(testAction =>
       expect(

--- a/apps/server/src/modules/transfer/import/import-triggers.ts
+++ b/apps/server/src/modules/transfer/import/import-triggers.ts
@@ -74,8 +74,9 @@ function allHandlersImporter(
       handlers,
       (handler: FlogoAppModel.Handler) => {
         const normalized = preNormalizeHandler(createdAt, handler);
-        // todo: pass raw handler
-        return importHandler(triggerId, normalized, handler);
+        const imported = importHandler(triggerId, normalized, handler);
+        delete imported['action'];
+        return imported;
       },
       index => `.triggers[${triggerIndex}].handlers[${index}]`
     );


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
As described in [this comment](https://github.com/TIBCOSoftware/flogo-web/pull/1017#pullrequestreview-210524585):
- Handler action is persisted after import 
- Wrong test data in import handler specs

**What is the new behavior?**
- Handler action is not persisted after import 
- Fixed test data in import handler specs

