### PR TITLE
feat: seed ref agent and allow to skip type generation for functions

### DIFF
--- a/apps/server/src/modules/transfer/export/ref-agent.spec.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent.spec.ts
@@ -13,7 +13,7 @@ describe('ref agent', () => {
     ).toEqual('rest');
   });
 
-  test('it allow to skip the type generation', () => {
+  test('it allows to skip the type generation', () => {
     expect(
       refAgent.registerRef('github.com/project-flogo/contrib/function/string', true)
     ).toBe(undefined);
@@ -38,6 +38,9 @@ describe('ref agent', () => {
     expect(refAgent.registerRef('github.com/project-flogo/SOMETHING_ELSE/rest')).toEqual(
       'rest_2'
     );
+    expect(
+      refAgent.registerRef('github.com/project-flogo/SOMETHING_ELSE/rest_1')
+    ).toEqual('rest_1_1');
   });
 
   test('it formats into the flogo.json imports syntax', () => {
@@ -53,5 +56,48 @@ describe('ref agent', () => {
       'github.com/project-flogo/contrib/activity/log',
       'github.com/project-flogo/contrib/function/string',
     ]);
+  });
+
+  describe('with predetermined imports', () => {
+    beforeEach(() => {
+      refAgent = new RefAgent([
+        {
+          ref: 'github.com/project-flogo/contrib/activity/rest',
+          isAliased: true,
+          type: 'myCoolRestAlias',
+        },
+        {
+          ref: 'github.com/project-flogo/contrib/activity/log',
+          isAliased: true,
+          type: 'log',
+        },
+        {
+          ref: 'github.com/project-flogo/contrib/activity/wont-be-used',
+          isAliased: false,
+          type: 'wont-be-used',
+        },
+      ]);
+    });
+
+    test('it should return the corresponding predetermined type when registering a matching ref', () => {
+      expect(
+        refAgent.registerRef('github.com/project-flogo/contrib/activity/rest')
+      ).toEqual('myCoolRestAlias');
+    });
+
+    test('it should consider the predetermined imports when ensuring type uniqueness', () => {
+      expect(refAgent.registerRef('github.com/other-repo/log')).toEqual('log_1');
+    });
+
+    test('it should format only the used the imports', () => {
+      refAgent.registerRef('github.com/project-flogo/contrib/trigger/rest');
+      refAgent.registerRef('github.com/project-flogo/contrib/activity/rest');
+      refAgent.registerRef('github.com/external/repo/with-yet-another/rest');
+      expect(refAgent.formatImports()).toEqual([
+        'github.com/project-flogo/contrib/trigger/rest',
+        'myCoolRestAlias github.com/project-flogo/contrib/activity/rest',
+        'rest_1 github.com/external/repo/with-yet-another/rest',
+      ]);
+    });
   });
 });

--- a/apps/server/src/modules/transfer/export/ref-agent.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent.ts
@@ -1,3 +1,5 @@
+import { ParsedImport } from '../common/parsed-import';
+
 const formatImport = ([ref, { type, isAliased }]) => (isAliased ? `${type} ${ref}` : ref);
 
 interface ImportInfo {
@@ -8,6 +10,16 @@ interface ImportInfo {
 export class RefAgent {
   private imports = new Map<string, ImportInfo>();
   private uniqueTracker = new Map<string, number>();
+  private predetermined = new Map<string, ImportInfo>();
+
+  constructor(predeterminedImports?: ParsedImport[]) {
+    if (predeterminedImports) {
+      predeterminedImports.forEach(({ ref, type, isAliased }) => {
+        this.predetermined.set(ref, { type, isAliased });
+        this.uniqueTracker.set(type, 1);
+      });
+    }
+  }
 
   registerRef(ref: string, skipTypeGen?: boolean): string {
     if (this.imports.has(ref)) {
@@ -16,8 +28,7 @@ export class RefAgent {
 
     let importInfo: ImportInfo = { isAliased: false, type: undefined };
     if (!skipTypeGen) {
-      const [defaultType] = ref.split('/').slice(-1);
-      importInfo = this.ensureUniqueType(defaultType);
+      importInfo = this.createImportInfo(ref);
     }
 
     this.imports.set(ref, importInfo);
@@ -28,8 +39,15 @@ export class RefAgent {
     return Array.from(this.imports.entries()).map(formatImport);
   }
 
-  hasRef(ref: string) {
-    return this.imports.has(ref);
+  private createImportInfo(ref: string): ImportInfo {
+    let importInfo: ImportInfo;
+    if (this.predetermined.has(ref)) {
+      importInfo = this.predetermined.get(ref);
+    } else {
+      const [defaultType] = ref.split('/').slice(-1);
+      importInfo = this.ensureUniqueType(defaultType);
+    }
+    return importInfo;
   }
 
   private ensureUniqueType(type: string): { type: string; isAliased: boolean } {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

Complement for #1024 to support:
1. Skipping type generation in exporter's ref agent for function ref registration
2. Creating of RefAgent from an initial set of ref/type information and use that info for `imports` generation