### PR TITLE
feat(server): function ref finder by function name

### DIFF
--- a/apps/server/src/modules/transfer/export/ref-agent/create-ref-agent.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent/create-ref-agent.ts
@@ -1,0 +1,11 @@
+import { ContributionSchema } from '@flogo-web/core';
+import { ParsedImport } from '../../common/parsed-import';
+import { RefAgent } from './ref-agent';
+import { FunctionRefFinder } from './function-ref-finder';
+
+export function createRefAgent(
+  contributions: ContributionSchema[],
+  predeterminedImports?: ParsedImport[]
+): RefAgent {
+  return new RefAgent(new FunctionRefFinder(contributions), predeterminedImports);
+}

--- a/apps/server/src/modules/transfer/export/ref-agent/function-ref-finder.spec.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent/function-ref-finder.spec.ts
@@ -1,0 +1,162 @@
+import { ContributionSchema } from '@flogo-web/core';
+import { FunctionRefFinder } from './function-ref-finder';
+
+test('It finds the functions by name', () => {
+  const lookup = new FunctionRefFinder(getTestData());
+  expect(lookup.findPackage('number.random')).toEqual(
+    'github.com/project-flogo/contrib/function/number'
+  );
+  expect(lookup.findPackage('string.equalsIgnoreCase')).toEqual(
+    'github.com/project-flogo/contrib/function/string'
+  );
+  expect(lookup.findPackage('string.float')).toEqual(
+    'github.com/project-flogo/contrib/function/string'
+  );
+  expect(() => lookup.findPackage('unknown')).not.toThrow();
+});
+
+function getTestData(): ContributionSchema[] {
+  return [
+    {
+      name: 'flogo-timer',
+      version: '0.0.2',
+      title: 'Timer',
+      type: 'flogo:trigger',
+      description: 'Simple Timer trigger',
+      homepage: 'https://github.com/project-flogo/contrib/tree/master/trigger/timer',
+      ref: 'github.com/project-flogo/contrib/trigger/timer',
+      handler: {
+        settings: [
+          {
+            name: 'startDelay',
+            type: 'string',
+          },
+          {
+            name: 'repeatInterval',
+            type: 'string',
+          },
+        ],
+      },
+    },
+    {
+      ref: 'github.com/project-flogo/contrib/function/number',
+      name: 'number',
+      type: 'flogo:function',
+      version: '0.0.1',
+      title: 'Number Functions',
+      description: 'Number Functions',
+      homepage: 'https://github.com/prject-flogo/contrib/tree/master/function/number',
+      functions: [
+        {
+          name: 'number.random',
+          description: 'generate a random number',
+          varArgs: true,
+          args: [
+            {
+              name: 'limit',
+              type: 'int',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      ref: 'github.com/project-flogo/contrib/function/string',
+      name: 'string',
+      type: 'flogo:function',
+      version: '0.0.1',
+      title: 'String Functions',
+      description: 'String Functions',
+      homepage: 'https://github.com/project-flogo/contrib/tree/master/function/string',
+      functions: [
+        {
+          name: 'string.concat',
+          description: 'concatenate a set of string',
+          varArgs: true,
+          args: [
+            {
+              name: 'str',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          name: 'string.equals',
+          description: 'check if two strings are equal',
+          args: [
+            {
+              name: 'str1',
+              type: 'string',
+            },
+            {
+              name: 'str2',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          name: 'string.equalsIgnoreCase',
+          description: 'check if two strings are equal ignoring case',
+          args: [
+            {
+              name: 'str1',
+              type: 'string',
+            },
+            {
+              name: 'str2',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          name: 'string.float',
+          description: 'convert the string to a float',
+          args: [
+            {
+              name: 'str1',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          name: 'string.integer',
+          description: 'convert the string to an integer',
+          args: [
+            {
+              name: 'str1',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          name: 'string.len',
+          description: 'get the length of a string',
+          args: [
+            {
+              name: 'str1',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          name: 'string.substring',
+          description: 'get a substring from a string',
+          args: [
+            {
+              name: 'str',
+              type: 'string',
+            },
+            {
+              name: 'start',
+              type: 'string',
+            },
+            {
+              name: 'end',
+              type: 'string',
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}

--- a/apps/server/src/modules/transfer/export/ref-agent/function-ref-finder.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent/function-ref-finder.ts
@@ -1,0 +1,32 @@
+import {
+  ContributionSchema,
+  FunctionsSchema,
+  SingleFunctionSchema,
+} from '@flogo-web/core';
+
+// todo: should be a core utility?
+const isFunctionContrib = (c: ContributionSchema): c is FunctionsSchema =>
+  // todo: should be a core constant?
+  c.type === 'flogo:function';
+
+export class FunctionRefFinder {
+  private functions = new Map<string, string>();
+
+  constructor(fromContribs: ContributionSchema[]) {
+    fromContribs.forEach((contrib: ContributionSchema) => {
+      if (isFunctionContrib(contrib) && contrib.functions) {
+        contrib.functions.forEach(addToFunctions(this.functions, contrib.ref));
+      }
+    });
+  }
+
+  findPackage(functionName: string) {
+    return this.functions.get(functionName);
+  }
+}
+
+function addToFunctions(functions: Map<string, string>, packageRef: string) {
+  return (f: SingleFunctionSchema) => {
+    functions.set(f.name, packageRef);
+  };
+}

--- a/apps/server/src/modules/transfer/export/ref-agent/index.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent/index.ts
@@ -1,0 +1,2 @@
+export { RefAgent } from './ref-agent';
+export { createRefAgent } from './create-ref-agent';

--- a/apps/server/src/modules/transfer/export/ref-agent/ref-agent.spec.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent/ref-agent.spec.ts
@@ -1,10 +1,18 @@
 import { RefAgent } from './ref-agent';
+import { FunctionRefFinder } from './function-ref-finder';
 
 describe('ref agent', () => {
   let refAgent: RefAgent;
+  const functionsReverseLookupStub: Partial<FunctionRefFinder> = {
+    findPackage(functionName: string) {
+      if (functionName === 'used.function') {
+        return 'github.com/some-package-with-functions/ref';
+      }
+    },
+  };
 
   beforeEach(() => {
-    refAgent = new RefAgent();
+    refAgent = new RefAgent(functionsReverseLookupStub as FunctionRefFinder);
   });
 
   test('it returns the type from a ref', () => {
@@ -49,18 +57,20 @@ describe('ref agent', () => {
     refAgent.registerRef('github.com/project-flogo/contrib/trigger/rest');
     refAgent.registerRef('github.com/project-flogo/contrib/activity/log');
     refAgent.registerRef('github.com/project-flogo/contrib/function/string', true);
+    refAgent.registerFunctionName('used.function');
     expect(refAgent.formatImports()).toEqual([
       'github.com/project-flogo/flow',
       'github.com/project-flogo/contrib/activity/rest',
       'rest_1 github.com/project-flogo/contrib/trigger/rest',
       'github.com/project-flogo/contrib/activity/log',
       'github.com/project-flogo/contrib/function/string',
+      'github.com/some-package-with-functions/ref',
     ]);
   });
 
   describe('with predetermined imports', () => {
     beforeEach(() => {
-      refAgent = new RefAgent([
+      refAgent = new RefAgent(functionsReverseLookupStub as FunctionRefFinder, [
         {
           ref: 'github.com/project-flogo/contrib/activity/rest',
           isAliased: true,

--- a/apps/server/src/modules/transfer/export/ref-agent/ref-agent.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent/ref-agent.ts
@@ -1,4 +1,5 @@
-import { ParsedImport } from '../common/parsed-import';
+import { ParsedImport } from '../../common/parsed-import';
+import { FunctionRefFinder } from './function-ref-finder';
 
 const formatImport = ([ref, { type, isAliased }]) => (isAliased ? `${type} ${ref}` : ref);
 
@@ -12,7 +13,10 @@ export class RefAgent {
   private uniqueTracker = new Map<string, number>();
   private predetermined = new Map<string, ImportInfo>();
 
-  constructor(predeterminedImports?: ParsedImport[]) {
+  constructor(
+    private functionsReverseLookup: FunctionRefFinder,
+    predeterminedImports?: ParsedImport[]
+  ) {
     if (predeterminedImports) {
       predeterminedImports.forEach(({ ref, type, isAliased }) => {
         this.predetermined.set(ref, { type, isAliased });
@@ -33,6 +37,13 @@ export class RefAgent {
 
     this.imports.set(ref, importInfo);
     return importInfo.type;
+  }
+
+  registerFunctionName(functionName: string) {
+    const ref = this.functionsReverseLookup.findPackage(functionName);
+    if (ref && !this.imports.has(ref)) {
+      this.imports.set(ref, { isAliased: false, type: undefined });
+    }
   }
 
   formatImports(): string[] {

--- a/libs/core/src/lib/interfaces/contributions/functions.ts
+++ b/libs/core/src/lib/interfaces/contributions/functions.ts
@@ -8,6 +8,7 @@ interface FunctionArgument {
 export interface SingleFunctionSchema {
   name: string;
   description?: string;
+  varArgs?: boolean;
   args?: FunctionArgument[];
 }
 


### PR DESCRIPTION
Add function ref finder by function name to ref agent.

Usage:

```ts
import { createRefAgent, RefAgent  } from 'modules/transfer/export/ref-agent';

const initialImports = [/* imports */];
const contributionSchemas = [
    {
     ref: 'github.com/project-flogo/contrib/function/string',
     functions: [{ name: 'string.concat' }]
   },
   // ...more
];
const refAgent: RefAgent = createRefAgent(contributionSchemas, initialImports);

refAgent.registerFunctionName('string.concat');

// outputs ['github.com/project-flogo/contrib/function/string']
console.log(refAgent.formatImports());

```