### PR TITLE
fix(server): cannot export a hander that does not define mappings

### DIFF
--- a/libs/server/core/src/lib/extensions/app-imports-agent.ts
+++ b/libs/server/core/src/lib/extensions/app-imports-agent.ts
@@ -1,4 +1,4 @@
 export interface AppImportsAgent {
-  registerRef(string): string | undefined;
-  registerFunctionName(string): void;
+  registerRef(ref: string): string | undefined;
+  registerFunctionName(functionName: string): void;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
An error is thrown when exporting a handler that doesn't define inputs nor mappings.

It seems that it only happens when it is a handler that was imported like that.


**What is the new behavior?**
Added checks for empty input/output mappings
