### PR TITLE
feat: use `#ref` instead of type on export and models

### DIFF
--- a/apps/server/src/modules/transfer/export/app-formatter/app-formatter.ts
+++ b/apps/server/src/modules/transfer/export/app-formatter/app-formatter.ts
@@ -16,7 +16,7 @@ import { createRefAgent, RefAgent } from '../ref-agent';
 const APP_MODEL_VERSION = '1.0.0';
 const TRIGGER_KEYS: Array<keyof FlogoAppModel.Trigger> = [
   'id',
-  'type',
+  'ref',
   'name',
   'description',
   'settings',
@@ -96,7 +96,7 @@ export class AppFormatter {
           {
             ...trigger,
             handlers: trigger.handlers.map(handlerFormatter(trigger)),
-            type: importsAgent.registerRef(trigger.ref),
+            ref: importsAgent.registerRef(trigger.ref),
           },
           TRIGGER_KEYS
         ) as FlogoAppModel.Trigger;

--- a/apps/server/src/modules/transfer/export/app-formatter/handler-format.ts
+++ b/apps/server/src/modules/transfer/export/app-formatter/handler-format.ts
@@ -53,7 +53,7 @@ function preFormatHandler(
   return {
     settings: !isEmpty(settings) ? { ...settings } : undefined,
     action: {
-      type: refAgent.registerRef(ref),
+      ref: refAgent.registerRef(ref),
       settings: null,
       ...actionMappings,
     },

--- a/apps/server/src/modules/transfer/export/export-app.spec.ts
+++ b/apps/server/src/modules/transfer/export/export-app.spec.ts
@@ -94,7 +94,7 @@ function getExpectedApp(): FlogoAppModel.App {
     triggers: [
       {
         id: 'receive_http_message',
-        type: 'rest',
+        ref: '#rest',
         name: 'Receive HTTP Message',
         description: 'Simple REST Trigger',
         settings: {
@@ -107,7 +107,7 @@ function getExpectedApp(): FlogoAppModel.App {
               path: '/test',
             },
             action: {
-              type: 'flow',
+              ref: '#flow',
               settings: {
                 resourceId: 'exported=flow:some_flow',
               },

--- a/apps/server/src/modules/transfer/export/ref-agent/ref-agent.spec.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent/ref-agent.spec.ts
@@ -18,13 +18,7 @@ describe('ref agent', () => {
   test('it returns the type from a ref', () => {
     expect(
       refAgent.registerRef('github.com/project-flogo/contrib/activity/rest')
-    ).toEqual('rest');
-  });
-
-  test('it allows to skip the type generation', () => {
-    expect(
-      refAgent.registerRef('github.com/project-flogo/contrib/function/string', true)
-    ).toBe(undefined);
+    ).toEqual('#rest');
   });
 
   test('it returns the same type for the same ref', () => {
@@ -34,21 +28,21 @@ describe('ref agent', () => {
 
   test('it ensures types are unique', () => {
     expect(refAgent.registerRef('github.com/project-flogo/ACTIVITY/rest')).toEqual(
-      'rest'
+      '#rest'
     );
     expect(refAgent.registerRef('github.com/project-flogo/TRIGGER/rest')).toEqual(
-      'rest_1'
+      '#rest_1'
     );
     // repeated on purpose
     expect(refAgent.registerRef('github.com/project-flogo/TRIGGER/rest')).toEqual(
-      'rest_1'
+      '#rest_1'
     );
     expect(refAgent.registerRef('github.com/project-flogo/SOMETHING_ELSE/rest')).toEqual(
-      'rest_2'
+      '#rest_2'
     );
     expect(
       refAgent.registerRef('github.com/project-flogo/SOMETHING_ELSE/rest_1')
-    ).toEqual('rest_1_1');
+    ).toEqual('#rest_1_1');
   });
 
   test('it formats into the flogo.json imports syntax', () => {
@@ -56,12 +50,10 @@ describe('ref agent', () => {
     refAgent.registerRef('github.com/project-flogo/contrib/activity/rest');
     refAgent.registerRef('github.com/project-flogo/contrib/trigger/rest');
     refAgent.registerRef('github.com/project-flogo/contrib/activity/log');
-    refAgent.registerRef('github.com/project-flogo/contrib/function/string', true);
     refAgent.registerFunctionName('used.function');
     expect(refAgent.formatImports()).toEqual([
       'github.com/project-flogo/contrib/activity/log',
       'github.com/project-flogo/contrib/activity/rest',
-      'github.com/project-flogo/contrib/function/string',
       'rest_1 github.com/project-flogo/contrib/trigger/rest',
       'github.com/project-flogo/flow',
       'github.com/some-package-with-functions/ref',
@@ -92,11 +84,11 @@ describe('ref agent', () => {
     test('it should return the corresponding predetermined type when registering a matching ref', () => {
       expect(
         refAgent.registerRef('github.com/project-flogo/contrib/activity/rest')
-      ).toEqual('myCoolRestAlias');
+      ).toEqual('#myCoolRestAlias');
     });
 
     test('it should consider the predetermined imports when ensuring type uniqueness', () => {
-      expect(refAgent.registerRef('github.com/other-repo/log')).toEqual('log_1');
+      expect(refAgent.registerRef('github.com/other-repo/log')).toEqual('#log_1');
     });
 
     test('it should format only the used the imports', () => {

--- a/apps/server/src/modules/transfer/export/ref-agent/ref-agent.ts
+++ b/apps/server/src/modules/transfer/export/ref-agent/ref-agent.ts
@@ -1,6 +1,6 @@
+import { AppImportsAgent } from '@flogo-web/server/core';
 import { ParsedImport } from '../../common/parsed-import';
 import { FunctionRefFinder } from './function-ref-finder';
-import { AppImportsAgent } from '@flogo-web/server/core';
 
 const formatImport = ([ref, { type, isAliased }]) => (isAliased ? `${type} ${ref}` : ref);
 
@@ -26,18 +26,15 @@ export class RefAgent implements AppImportsAgent {
     }
   }
 
-  registerRef(ref: string, skipTypeGen?: boolean): string {
-    if (this.imports.has(ref)) {
-      return !skipTypeGen ? this.imports.get(ref).type : undefined;
-    }
-
-    let importInfo: ImportInfo = { isAliased: false, type: undefined };
-    if (!skipTypeGen) {
+  registerRef(ref: string): string {
+    let importInfo: ImportInfo;
+    if (!this.imports.has(ref)) {
       importInfo = this.createImportInfo(ref);
+      this.imports.set(ref, importInfo);
+    } else {
+      importInfo = this.imports.get(ref);
     }
-
-    this.imports.set(ref, importInfo);
-    return importInfo.type;
+    return importInfo && importInfo.type ? `#${importInfo.type}` : undefined;
   }
 
   registerFunctionName(functionName: string) {

--- a/libs/core/src/lib/engine/interfaces.ts
+++ b/libs/core/src/lib/engine/interfaces.ts
@@ -20,9 +20,7 @@ export namespace FlogoAppModel {
 
   export interface Trigger {
     id: string;
-    ref?: string;
-    // only >= v0.9.0
-    type?: string;
+    ref: string;
     // todo: confirm required
     name?: string;
     description?: string;
@@ -53,8 +51,7 @@ export namespace FlogoAppModel {
   export interface NewHandler {
     settings: Settings;
     action: {
-      ref?: string;
-      type?: string;
+      ref: string;
       settings: Settings;
       input: {
         [inputName: string]: any;
@@ -119,8 +116,7 @@ export namespace ResourceActionModel {
    * from >= v0.9.0
    * */
   export interface NewActivity {
-    ref?: string;
-    type?: string;
+    ref: string;
     settings?: {
       [settingName: string]: any;
     };

--- a/libs/plugins/flow-server/src/lib/export/task-formatter.ts
+++ b/libs/plugins/flow-server/src/lib/export/task-formatter.ts
@@ -49,7 +49,7 @@ export class TaskFormatter {
       description: !isEmpty(description) ? description : undefined,
       settings: !isEmpty(taskSettings) ? taskSettings : undefined,
       activity: {
-        type: this.importsAgent.registerRef(activityRef),
+        ref: this.importsAgent.registerRef(activityRef),
         input: !isEmpty(input) ? input : undefined,
         settings: !isEmpty(activitySettings) ? activitySettings : undefined,
       },

--- a/libs/plugins/flow-server/src/lib/export/tests/export.spec.ts
+++ b/libs/plugins/flow-server/src/lib/export/tests/export.spec.ts
@@ -39,7 +39,7 @@ function getExpectedFlow(): FlogoAppModel.Resource<ResourceActionModel.FlowResou
           name: 'Log',
           description: 'Logs a message',
           activity: {
-            type: 'some_path_to_repo/activity/log',
+            ref: 'some_path_to_repo/activity/log',
             input: {
               message: 'hello world',
               addDetails: false,
@@ -51,7 +51,7 @@ function getExpectedFlow(): FlogoAppModel.Resource<ResourceActionModel.FlowResou
           name: 'Start a SubFlow',
           description: 'Activity to start a sub-flow in an existing flow',
           activity: {
-            type: CONTRIB_REFS.SUBFLOW,
+            ref: CONTRIB_REFS.SUBFLOW,
             settings: {
               flowURI: 'res://flow:humanized_subflow_ref',
             },
@@ -71,7 +71,7 @@ function getExpectedFlow(): FlogoAppModel.Resource<ResourceActionModel.FlowResou
             name: 'Log',
             description: 'Logs a message',
             activity: {
-              type: 'some_path_to_repo/activity/log',
+              ref: 'some_path_to_repo/activity/log',
               input: {
                 message: 'hello world from the error handler',
                 addDetails: true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
- Exported app uses `type` instead of `ref`
- Interfaces define optional `type` and optional `ref`

**What is the new behavior?**
- Exported app uses new syntax `ref: "#ref"`
- Interfaces define only `ref` as required