### PR TITLE
[1028] Removed the transformations to functions schema

### DIFF
--- a/libs/client-core/src/interfaces/common/contrib-schema.ts
+++ b/libs/client-core/src/interfaces/common/contrib-schema.ts
@@ -22,7 +22,6 @@ export interface TriggerSchema extends BaseSchema {
 export interface FunctionSchema extends BaseSchema {
   type: 'flogo:function';
   functions: any[];
-  namespace: string;
 }
 export interface SchemaAttribute {
   name: string;

--- a/libs/plugins/flow-client/src/lib/core/interfaces/installed-functions.ts
+++ b/libs/plugins/flow-client/src/lib/core/interfaces/installed-functions.ts
@@ -3,5 +3,4 @@ export interface InstalledFunctionSchema {
   ref: string;
   functions: any[];
   type: string;
-  namespace: string;
 }

--- a/libs/plugins/flow-client/src/lib/core/state/flow/flow.reducer.ts
+++ b/libs/plugins/flow-client/src/lib/core/state/flow/flow.reducer.ts
@@ -15,40 +15,6 @@ import { runnerReducer } from './runner.reducer';
 
 const ActionType = actions.ActionType;
 
-function normalizeFunctionSchema(functionSchema) {
-  return {
-    ...functionSchema,
-    namespace:
-      functionSchema.functions && functionSchema.functions.length
-        ? functionSchema.functions[0].name.split('.')[0]
-        : undefined,
-    functions:
-      functionSchema.functions &&
-      functionSchema.functions.map(eachFunction => {
-        return {
-          ...eachFunction,
-          name: eachFunction.name.split('.')[1],
-          //ToDo: Remove once the fix for below in contrib is released
-          args:
-            eachFunction.args &&
-            eachFunction.args.map(eachArg => {
-              return {
-                ...normalizeArgs(eachArg),
-              };
-            }),
-        };
-      }),
-  };
-
-  function normalizeArgs(args) {
-    const normalizedArgs = {};
-    Object.keys(args).forEach(arg => {
-      normalizedArgs[arg.trim()] = args[arg];
-    });
-    return normalizedArgs;
-  }
-}
-
 export function flowReducer(
   state: FlowState = INITIAL_STATE,
   action: actions.ActionsUnion
@@ -56,23 +22,9 @@ export function flowReducer(
   state = runnerReducer(state, action);
   switch (action.type) {
     case ActionType.Init: {
-      const allFunctionSchemas = {};
-      Object.keys(action.payload.schemas)
-        .filter(contribSchema => {
-          return action.payload.schemas[contribSchema].type === 'flogo:function';
-        })
-        .forEach(functionRef => {
-          allFunctionSchemas[functionRef] = normalizeFunctionSchema(
-            action.payload.schemas[functionRef]
-          );
-        });
       return {
         ...INITIAL_STATE,
         ...action.payload,
-        schemas: {
-          ...action.payload.schemas,
-          ...allFunctionSchemas,
-        },
       };
     }
     case ActionType.SelectItem: {
@@ -165,7 +117,7 @@ export function flowReducer(
         ...state,
         schemas: {
           ...state.schemas,
-          [action.payload.ref]: normalizeFunctionSchema(action.payload),
+          [action.payload.ref]: action.payload,
         },
       };
     }

--- a/libs/plugins/flow-client/src/lib/core/state/flow/flow.selectors.ts
+++ b/libs/plugins/flow-client/src/lib/core/state/flow/flow.selectors.ts
@@ -328,7 +328,6 @@ export const getInstalledFunctions = createSelector(
         functions: schema.functions,
         name: schema.name,
         type: schema.type,
-        namespace: schema.namespace,
         ref: schema.ref,
       }));
   }

--- a/libs/plugins/flow-client/src/lib/shared/mapper/services/tree-node-factory.service.ts
+++ b/libs/plugins/flow-client/src/lib/shared/mapper/services/tree-node-factory.service.ts
@@ -4,6 +4,7 @@ import * as lodash from 'lodash';
 import { TreeNode } from 'primeng/components/common/api';
 import { MapperTreeNode } from '../models';
 import { ArrayMappingInfo } from '../models/array-mapping';
+import { InstalledFunctionSchema } from '../../../core';
 
 @Injectable()
 export class TreeNodeFactoryService {
@@ -92,8 +93,7 @@ export class TreeNodeFactoryService {
     // return result;
   }
 
-  // todo: functions type
-  fromFunctions(functionMap: any) {
+  fromFunctions(functionMap: InstalledFunctionSchema[]) {
     // is it an object?
     if (functionMap !== Object(functionMap)) {
       return [];
@@ -118,16 +118,13 @@ export class TreeNodeFactoryService {
     let node = {};
     Object.keys(functionMap).forEach(func => {
       const currentFunction = functionMap[func];
-      if (currentFunction.namespace) {
+      if (currentFunction.functions && currentFunction.functions.length > 0) {
         Object.keys(currentFunction.functions).forEach(subFunc => {
           const currentChildFunction = currentFunction.functions[subFunc];
-          node = this.createFromFunctionsNode(
-            currentChildFunction,
-            currentFunction.namespace
-          );
-          pushToCategory(currentFunction.namespace, node);
+          node = this.createFromFunctionsNode(currentChildFunction, currentFunction.name);
+          pushToCategory(currentFunction.name, node);
         });
-      } else if (!currentFunction.namespace) {
+      } else if (!currentFunction.functions) {
         node = this.createFromFunctionsNode(currentFunction);
         nodes.push(node);
       } else {
@@ -149,7 +146,7 @@ export class TreeNodeFactoryService {
     return sort(allNodes);
   }
 
-  private createFromFunctionsNode(currentFunction, namespace?) {
+  private createFromFunctionsNode(currentFunction, groupName?: string) {
     const functionName = currentFunction.name;
     const description = currentFunction.description;
     const args = currentFunction.args.reduce((allArgs, current) => {
@@ -162,8 +159,8 @@ export class TreeNodeFactoryService {
       return allArgs;
     }, []);
     let snippet = '';
-    if (namespace) {
-      snippet = `${namespace}.${functionName}(${args.join(', ')})`;
+    if (groupName) {
+      snippet = `${groupName}.${functionName}(${args.join(', ')})`;
     } else {
       snippet = `${functionName}(${args.join(', ')})`;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The old function contributions schema does not have importance for grouping / namespaces in their descriptor JSON. We had to prepare the data from the descriptor JSON of the function contributions. 

**What is the new behavior?**
Recently contrib CLI has updated their descriptor JSON to follow :
```
{
    name ---> ${namespace}
    function: [{
        name ---> ${function_name}
    }]
}
```

And we are preparing the snippet of the functions as `${namespace}.${function_name}`

**Other information**:
Currently the contribution repositories are not released with the changes. You can get the updated function contributions by installing the following contrib bundle file in `dist/local/engines/flogo-web`:

bundle file:
```json
{
  "name": "update functions",
  "description": "update functions",
  "contributions": [
    "github.com/project-flogo/contrib/function/string@master",
    "github.com/project-flogo/contrib/function/number@master",
    "github.com/project-flogo/contrib/function/json@master"
  ]
}
```

command to install bundle (saved above JSON to contrib-bundle.json in `dist/local/engines/flogo-web`): 
```sh
flogo install --file contrib-bundle.json
```

And restart the server