### PR TITLE
fix(client): navigation to flow from recent edit apps link

### DIFF
--- a/apps/client/src/flogo/home/home.component.html
+++ b/apps/client/src/flogo/home/home.component.html
@@ -44,7 +44,7 @@
       <ul class="recent-flows__list">
         <li *ngFor="let item of recent" class="recent-flows__list__item">
           <span class="recent-flows__flow__name"
-            ><a [routerLink]="['/flows', item.id]" class="flogo-link">{{
+            ><a [routerLink]="['/resources', item.id, item.type]" class="flogo-link">{{
               item.name
             }}</a></span
           >


### PR DESCRIPTION
fixed the issue the links to the flows in the "Recent Applications" in home page is broken

fixes #1052

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#1052 - The links to the flows in the "Recent Applications" in home page is broken

**What is the new behavior?**
Fixed the issue. Navigation to an app from recent edit apps section in homepage will work as expected.


